### PR TITLE
Split mutable and immutable txn state

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -7,8 +7,8 @@ pub struct Db {
 }
 
 impl Db {
-    pub async fn open<P: AsRef<Path>>(root: P, options: Options) -> Result<Self> {
-        let table = Table::open(Photon, root, options).await?;
+    pub async fn open<P: AsRef<Path>>(path: P, options: Options) -> Result<Self> {
+        let table = Table::open(Photon, path, options).await?;
         Ok(Db { table })
     }
 }

--- a/src/page_store/mod.rs
+++ b/src/page_store/mod.rs
@@ -1,13 +1,15 @@
+use std::path::Path;
+
+use crate::env::Env;
+
 mod error;
 pub(crate) use error::{Error, Result};
 
 mod page_txn;
-pub(crate) use page_txn::PageTxn;
+pub(crate) use page_txn::{Guard, PageTxn};
 
 mod page_table;
 use page_table::PageTable;
-
-use crate::env::Env;
 
 pub(crate) struct PageStore<E> {
     env: E,
@@ -15,11 +17,11 @@ pub(crate) struct PageStore<E> {
 }
 
 impl<E: Env> PageStore<E> {
-    pub(crate) async fn open(env: E) -> Result<Self> {
+    pub(crate) async fn open<P: AsRef<Path>>(env: E, path: P) -> Result<Self> {
         todo!()
     }
 
-    pub(crate) fn begin(&self) -> PageTxn {
+    pub(crate) fn guard(&self) -> Guard {
         todo!()
     }
 }

--- a/src/page_store/page_txn.rs
+++ b/src/page_store/page_txn.rs
@@ -1,39 +1,49 @@
 use super::Result;
 use crate::page::{PageBuf, PageRef};
 
-pub(crate) struct PageTxn;
+pub(crate) struct Guard;
 
-impl PageTxn {
-    pub(crate) fn alloc_id(&self) -> u64 {
-        todo!()
-    }
-
-    pub(crate) fn dealloc_id(&self, id: u64) {
-        todo!()
-    }
-
-    pub(crate) fn alloc_page(&self, size: usize) -> Result<(u64, PageBuf<'_>)> {
-        todo!()
-    }
-
-    pub(crate) fn dealloc_page(&self, addr: u64) {
-        todo!()
-    }
-
-    pub(crate) async fn read_page(&self, addr: u64) -> Result<PageRef<'_>> {
-        todo!()
+impl Guard {
+    pub(crate) fn begin(&self) -> PageTxn<'_> {
+        PageTxn { guard: self }
     }
 
     pub(crate) fn page_addr(&self, id: u64) -> u64 {
         todo!()
     }
 
-    pub(crate) fn update_page(&self, id: u64, old: u64, new: u64) -> Result<()> {
+    pub(crate) async fn read_page(&self, addr: u64) -> Result<PageRef<'_>> {
+        todo!()
+    }
+}
+
+pub(crate) struct PageTxn<'a> {
+    guard: &'a Guard,
+}
+
+impl<'a> PageTxn<'a> {
+    pub(crate) fn alloc_id(&mut self) -> u64 {
+        todo!()
+    }
+
+    pub(crate) fn dealloc_id(&mut self, id: u64) {
+        todo!()
+    }
+
+    pub(crate) fn alloc_page(&mut self, size: usize) -> Result<(u64, PageBuf<'a>)> {
+        todo!()
+    }
+
+    pub(crate) fn dealloc_page(&mut self, addr: u64) {
+        todo!()
+    }
+
+    pub(crate) fn update_page(&mut self, id: u64, old: u64, new: u64) -> Result<()> {
         // TODO: ensures that old < new so that we can recover the page table in order.
         todo!()
     }
 
-    pub(crate) fn replace_page(&self, id: u64, old: u64, new: u64) -> Result<()> {
+    pub(crate) fn replace_page(&mut self, id: u64, old: u64, new: u64) -> Result<()> {
         // TODO: ensures that old < new so that we can recover the page table in order.
         todo!()
     }
@@ -41,7 +51,7 @@ impl PageTxn {
     pub(crate) fn commit(self) {}
 }
 
-impl Drop for PageTxn {
+impl<'a> Drop for PageTxn<'a> {
     fn drop(&mut self) {
         // abort the transaction
         todo!()

--- a/src/table.rs
+++ b/src/table.rs
@@ -13,8 +13,8 @@ pub struct Table<E> {
 }
 
 impl<E: Env> Table<E> {
-    pub(crate) async fn open<P: AsRef<Path>>(env: E, root: P, opts: Options) -> Result<Self> {
-        let tree = Tree::open(env, opts).await?;
+    pub(crate) async fn open<P: AsRef<Path>>(env: E, path: P, options: Options) -> Result<Self> {
+        let tree = Tree::open(env, path, options).await?;
         Ok(Self { tree })
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,39 +1,27 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::path::Path;
 
 use crate::{
     data::{Entry, Key, Range},
     env::Env,
     page::{PageBuf, PageEpoch, PageKind, PageRef, PageTier, SortedPageBuilder},
-    page_store::{Error, PageStore, PageTxn, Result},
+    page_store::{Error, Guard, PageStore, PageTxn, Result},
     Options,
 };
 
 pub(crate) struct Tree<E> {
-    opts: Options,
-    root: AtomicId,
+    options: Options,
     store: PageStore<E>,
 }
 
 impl<E: Env> Tree<E> {
-    pub(crate) async fn open(env: E, opts: Options) -> Result<Self> {
-        let store = PageStore::open(env).await?;
-        let txn = store.begin();
-        let root = txn.alloc_id();
-        txn.commit();
-        Ok(Self {
-            opts,
-            root: AtomicId::new(root),
-            store,
-        })
+    pub(crate) async fn open<P: AsRef<Path>>(env: E, path: P, options: Options) -> Result<Self> {
+        let store = PageStore::open(env, path).await?;
+        Ok(Self { options, store })
     }
 
     fn begin(&self) -> TreeTxn {
-        let txn = self.store.begin();
-        TreeTxn {
-            txn,
-            opts: &self.opts,
-            root: &self.root,
-        }
+        let guard = self.store.guard();
+        TreeTxn::new(&self.options, guard)
     }
 
     pub(crate) async fn get<F, R>(&self, key: Key<'_>, f: F) -> Result<R>
@@ -63,37 +51,42 @@ impl<E: Env> Tree<E> {
 }
 
 struct TreeTxn<'a> {
-    txn: PageTxn,
-    opts: &'a Options,
-    root: &'a AtomicId,
+    options: &'a Options,
+    guard: Guard,
 }
 
 impl<'a> TreeTxn<'a> {
+    fn new(options: &'a Options, guard: Guard) -> Self {
+        Self { options, guard }
+    }
+
     async fn get(&self, key: &Key<'_>) -> Result<Option<&[u8]>> {
-        let (view, _) = self.find_leaf(key).await?;
-        self.lookup_value(key, &view).await
+        let mut txn = self.guard.begin();
+        let (view, _) = self.find_leaf(&mut txn, key).await?;
+        self.find_value(&mut txn, key, &view).await
     }
 
     async fn write(&self, entry: &Entry<'_>) -> Result<()> {
-        let (mut view, _) = self.find_leaf(&entry.key).await?;
+        let mut txn = self.guard.begin();
+        let (mut view, _) = self.find_leaf(&mut txn, &entry.key).await?;
         // let builder = SortedPageBuilder::new(PageTier::Leaf, PageKind::Data);
-        let (new_addr, mut new_page) = self.txn.alloc_page(0)?;
+        let (new_addr, mut new_page) = txn.alloc_page(0)?;
         // builder.build(&mut new_page);
         loop {
             new_page.set_epoch(view.page.epoch());
             new_page.set_chain_len(view.page.chain_len());
             new_page.set_chain_next(view.addr.into());
-            match self.txn.update_page(view.id, view.addr, new_addr) {
+            match txn.update_page(view.id, view.addr, new_addr) {
                 Ok(_) => {
-                    if new_page.chain_len() as usize >= self.opts.page_chain_length {
+                    if new_page.chain_len() as usize >= self.options.page_chain_length {
                         view.page = new_page.into();
                         // It doesn't matter whether this consolidation succeeds or not.
-                        let _ = self.consolidate_page(view).await;
+                        let _ = self.consolidate_page(&mut txn, view).await;
                         return Ok(());
                     }
                 }
                 Err(Error::UpdatePage(addr)) => {
-                    let page = self.txn.read_page(addr).await?;
+                    let page = self.guard.read_page(addr).await?;
                     if page.epoch() == view.page.epoch() {
                         view.page = page;
                         continue;
@@ -105,14 +98,17 @@ impl<'a> TreeTxn<'a> {
         }
     }
 
-    async fn find_leaf(&self, key: &Key<'_>) -> Result<(PageView<'_>, Option<PageView<'_>>)> {
-        let root = self.root.get();
-        let mut index = PageIndex::new(root);
+    async fn find_leaf<'s: 't, 't>(
+        &'s self,
+        txn: &mut PageTxn<'t>,
+        key: &Key<'_>,
+    ) -> Result<(PageView<'t>, Option<PageView<'t>>)> {
+        let mut index = PageIndex::new(0);
         let mut range = Range::default();
         let mut parent = None;
         loop {
-            let addr = self.txn.page_addr(index.id);
-            let page = self.txn.read_page(addr).await?;
+            let addr = self.guard.page_addr(index.id);
+            let page = self.guard.read_page(addr).await?;
             let view = PageView {
                 id: index.id,
                 addr,
@@ -121,13 +117,13 @@ impl<'a> TreeTxn<'a> {
             };
             // Do not continue if the page epoch has changed.
             if view.page.epoch() != index.epoch {
-                self.reconcile_page(view, parent).await;
+                self.reconcile_page(txn, view, parent).await;
                 return Err(Error::Again);
             }
             if view.page.tier().is_leaf() {
                 return Ok((view, parent));
             }
-            let (child_index, child_range) = self.lookup_child(key, &view).await?;
+            let (child_index, child_range) = self.find_child(txn, key, &view).await?;
             index = child_index;
             range = child_range;
             parent = Some(view);
@@ -141,22 +137,37 @@ impl<'a> TreeTxn<'a> {
         Ok(())
     }
 
-    async fn lookup_value(&self, key: &Key<'_>, view: &PageView<'_>) -> Result<Option<&[u8]>> {
+    async fn find_value<'t>(
+        &self,
+        txn: &mut PageTxn<'t>,
+        key: &Key<'_>,
+        view: &PageView<'t>,
+    ) -> Result<Option<&[u8]>> {
         todo!()
     }
 
-    async fn lookup_child(&self, key: &Key<'_>, view: &PageView<'_>) -> Result<(PageIndex, Range)> {
+    async fn find_child<'t>(
+        &self,
+        txn: &mut PageTxn<'t>,
+        key: &Key<'_>,
+        view: &PageView<'t>,
+    ) -> Result<(PageIndex, Range)> {
         todo!()
     }
 
-    async fn reconcile_page(&self, view: PageView<'_>, parent: Option<PageView<'_>>) {
+    async fn reconcile_page<'t>(
+        &self,
+        txn: &mut PageTxn<'t>,
+        view: PageView<'t>,
+        parent: Option<PageView<'t>>,
+    ) {
         todo!()
     }
 
-    async fn consolidate_page(&self, view: PageView<'_>) -> Result<()> {
+    async fn consolidate_page<'t>(&self, txn: &mut PageTxn<'t>, view: PageView<'t>) -> Result<()> {
         let (iter, last_page) = self.delta_page_iter(&view).await;
         // let builder = DataPageBuilder::new(view.page.tier()).with_iter(iter);
-        let (new_addr, mut new_page) = self.txn.alloc_page(0)?;
+        let (new_addr, mut new_page) = txn.alloc_page(0)?;
         // builder.build(&mut new_page);
         new_page.set_epoch(view.page.epoch().next());
         new_page.set_chain_len(last_page.chain_len());
@@ -169,22 +180,6 @@ impl<'a> TreeTxn<'a> {
 
     async fn delta_page_iter(&self, view: &PageView<'_>) -> ((), PageRef<'_>) {
         todo!()
-    }
-}
-
-struct AtomicId(AtomicU64);
-
-impl AtomicId {
-    fn new(id: u64) -> Self {
-        Self(AtomicU64::new(id))
-    }
-
-    fn get(&self) -> u64 {
-        self.0.load(Ordering::Acquire)
-    }
-
-    fn set(&self, id: u64) {
-        self.0.store(id, Ordering::Release)
     }
 }
 


### PR DESCRIPTION
`Guard` holds the underlying resources. `PageTxn` holds the mutable transaction state. `PageTxn` also holds a `Guard` reference.