### PR TITLE
page_store: refine file_info retrieve method 

### DIFF
--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -123,7 +123,7 @@ impl FileBuilder {
 
         let active_pages = {
             let mut active_pages = roaring::RoaringBitmap::new();
-            for (page_addr, _) in &self.meta.page_table.0 {
+            for (_page_id, page_addr) in &self.meta.page_table.0 {
                 let (_, index) = split_page_addr(*page_addr);
                 active_pages.insert(index);
             }

--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -1,8 +1,12 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use photonio::{fs::File, io::WriteExt};
 
-use crate::page_store::{Error, Result};
+use super::{types::split_page_addr, FileInfo, FileMeta};
+use crate::page_store::{page_table, Error, Result};
 
 const IO_BUFFER_SIZE: usize = 4096 * 4;
 
@@ -23,6 +27,7 @@ const IO_BUFFER_SIZE: usize = 4096 * 4;
 /// `page_addr`'s high 32 bit always be `file-id`(`PageAddr = {file id} {write
 /// buffer index}`), so it only store lower 32 bit.
 pub(crate) struct FileBuilder {
+    file_id: u32,
     writer: BufferedWriter,
 
     index: IndexBlockBuilder,
@@ -33,9 +38,10 @@ pub(crate) struct FileBuilder {
 
 impl FileBuilder {
     /// Create new file builder for given writer.
-    pub(crate) fn new(file: File, use_direct: bool) -> Self {
+    pub(crate) fn new(file_id: u32, file: File, use_direct: bool) -> Self {
         let writer = BufferedWriter::new(file, IO_BUFFER_SIZE, use_direct);
         Self {
+            file_id,
             writer,
             index: Default::default(),
             meta: Default::default(),
@@ -67,10 +73,11 @@ impl FileBuilder {
     }
 
     // Finish build page file.
-    pub(crate) async fn finish(&mut self) -> Result<()> {
+    pub(crate) async fn finish(&mut self) -> Result<FileInfo> {
         self.finish_meta_block().await?;
-        self.finish_file_footer().await?;
-        self.writer.flush_and_sync().await
+        let info = self.finish_file_footer().await?;
+        self.writer.flush_and_sync().await?;
+        Ok(info)
     }
 }
 
@@ -89,7 +96,7 @@ impl FileBuilder {
         Ok(())
     }
 
-    async fn finish_file_footer(&mut self) -> Result<()> {
+    async fn finish_file_footer(&mut self) -> Result<FileInfo> {
         let footer = {
             let mut f = Footer::default();
             f.magic = 142857;
@@ -104,7 +111,28 @@ impl FileBuilder {
         let footer_dat = footer.encode();
         let _ = self.writer.write(&footer_dat).await?;
 
-        Ok(())
+        Ok(self.as_file_info(&footer))
+    }
+
+    fn as_file_info(&self, footer: &Footer) -> FileInfo {
+        let meta = {
+            let (indexes, offsets) = self.index.index_block.as_meta_file_cached(footer);
+            let file_size = self.writer.actual_data_size as u32;
+            Arc::new(FileMeta::new(self.file_id, file_size, indexes, offsets))
+        };
+
+        let active_pages = {
+            let mut active_pages = roaring::RoaringBitmap::new();
+            for (page_addr, _) in &self.meta.page_table.0 {
+                let (_, index) = split_page_addr(*page_addr);
+                active_pages.insert(index);
+            }
+            active_pages
+        };
+
+        let active_size = meta.total_page_size();
+
+        FileInfo::new(active_pages, 0.0, active_size, meta)
     }
 }
 
@@ -383,6 +411,15 @@ impl IndexBlock {
             meta_page_table,
             meta_delete_pages,
         })
+    }
+
+    pub(crate) fn as_meta_file_cached(&self, footer: &Footer) -> (Vec<u64>, BTreeMap<u64, u64>) {
+        let mut indexes = vec![
+            self.meta_page_table.as_ref().unwrap().to_owned(),
+            self.meta_delete_pages.as_ref().unwrap().to_owned(),
+            footer.data_handle.offset, // meta block's end is index_block's start.
+        ];
+        (indexes, self.page_offsets.to_owned())
     }
 }
 

--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -1,12 +1,12 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 
 use photonio::{fs::File, io::WriteExt};
 
 use super::{types::split_page_addr, FileInfo, FileMeta};
-use crate::page_store::{page_table, Error, Result};
+use crate::page_store::{Error, Result};
 
 const IO_BUFFER_SIZE: usize = 4096 * 4;
 
@@ -117,8 +117,7 @@ impl FileBuilder {
     fn as_file_info(&self, footer: &Footer) -> FileInfo {
         let meta = {
             let (indexes, offsets) = self.index.index_block.as_meta_file_cached(footer);
-            let file_size = self.writer.actual_data_size as u32;
-            Arc::new(FileMeta::new(self.file_id, file_size, indexes, offsets))
+            Arc::new(FileMeta::new(self.file_id, indexes, offsets))
         };
 
         let active_pages = {

--- a/src/page_store/page_file/file_reader.rs
+++ b/src/page_store/page_file/file_reader.rs
@@ -6,10 +6,7 @@ use super::{
     file_builder::{DeletePages, Footer, IndexBlock, PageTable},
     types::FileMeta,
 };
-use crate::{
-    page,
-    page_store::{Error, Result},
-};
+use crate::page_store::{Error, Result};
 
 pub(crate) struct FileReader<R: ReadAt> {
     reader: R,
@@ -88,7 +85,7 @@ impl<R: ReadAt> FileReader<R> {
         let index_block = Self::read_index_block(reader, &footer).await?;
         Ok({
             let (indexes, offsets) = index_block.as_meta_file_cached(&footer);
-            Arc::new(FileMeta::new(file_id, file_size, indexes, offsets))
+            Arc::new(FileMeta::new(file_id, indexes, offsets))
         })
     }
 

--- a/src/page_store/page_file/info_builder.rs
+++ b/src/page_store/page_file/info_builder.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, hash::Hash, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use photonio::fs::File;
 
-use super::{types::split_page_addr, FileInfo, FileMeta, FileReader};
+use super::{types::split_page_addr, FileInfo, FileReader};
 use crate::page_store::Result;
 
 pub(crate) struct FileInfoBuilder {

--- a/src/page_store/page_file/info_builder.rs
+++ b/src/page_store/page_file/info_builder.rs
@@ -42,15 +42,15 @@ impl FileInfoBuilder {
     // It copies the old file infos before add new file.
     // It could help version to prepare new Version's `active_files` after flush a
     // new page file.
-    pub(crate) async fn add_file_info(
+    pub(crate) fn add_file_info(
         &self,
-        files: HashMap<u32, FileInfo>,
-        new_file_id: &u32,
+        files: &HashMap<u32, FileInfo>,
+        new_file_info: FileInfo,
+        new_delete_pages: &[u64],
     ) -> Result<HashMap<u32, FileInfo>> {
         let mut files = files.clone();
-        let (new_file_info, new_delete_pages) = self.recovery_one_file(new_file_id).await?;
-        files.insert(*new_file_id, new_file_info);
-        Self::mantain_file_active_pages(&mut files, &new_delete_pages);
+        files.insert(new_file_info.get_file_id(), new_file_info);
+        Self::mantain_file_active_pages(&mut files, new_delete_pages);
         Ok(files)
     }
 
@@ -64,7 +64,7 @@ impl FileInfoBuilder {
                 .await
                 .expect("read page table error");
             let mut active_pages = roaring::RoaringBitmap::new();
-            for (page_addr, _) in page_table {
+            for (_page_id, page_addr) in page_table {
                 let (_, index) = split_page_addr(page_addr);
                 active_pages.insert(index);
             }
@@ -75,7 +75,7 @@ impl FileInfoBuilder {
 
         let delete_pages = file_reader.read_delete_pages().await?;
 
-        let decline_rate = todo!();
+        let decline_rate = 0.0; // todo:...
         let info = FileInfo::new(active_pages, decline_rate, active_size, meta);
 
         Ok((info, delete_pages))

--- a/src/page_store/page_file/mod.rs
+++ b/src/page_store/page_file/mod.rs
@@ -191,7 +191,6 @@ pub(crate) mod facade {
             };
 
             let info_builder = files.new_info_builder();
-
             {
                 // test add new files.
                 let mut mock_version = HashMap::new();
@@ -212,6 +211,7 @@ pub(crate) mod facade {
                 }
 
                 {
+                    // add an additional file with delete file1's page info.
                     let file_id = 2;
                     let delete_pages = &[page_addr(1, 0)];
 
@@ -228,15 +228,16 @@ pub(crate) mod facade {
                     b.add_delete_pages(delete_pages);
                     let file_info = b.finish().await.unwrap();
 
-                    let file1_before_add = mock_version.get(&1).unwrap().effective_size();
+                    let orignal_file1_active_size = mock_version.get(&1).unwrap().effective_size();
                     mock_version = info_builder
                         .add_file_info(&mock_version, file_info, delete_pages)
                         .unwrap();
 
                     let file1 = mock_version.get(&1).unwrap();
-                    assert_eq!(file1.effective_size(), file1_before_add - 10);
+                    assert_eq!(file1.effective_size(), orignal_file1_active_size - 10);
                     assert!(file1.get_page_handle(page_addr(1, 0)).is_none());
                     assert!(file1.get_page_handle(page_addr(1, 1)).is_some());
+
                     let file2 = mock_version.get(&2).unwrap();
                     let hd = file2.get_page_handle(page_addr(2, 4)).unwrap();
                     assert_eq!(hd.size, 10);

--- a/src/page_store/page_file/mod.rs
+++ b/src/page_store/page_file/mod.rs
@@ -123,12 +123,14 @@ pub(crate) mod facade {
 
     #[cfg(test)]
     mod tests {
+        use std::collections::HashMap;
+
         use super::*;
 
         #[photonio::test]
         fn test_file_builder() {
             let base = std::env::temp_dir();
-            let files = PageFiles::new(&base, "testdata");
+            let files = PageFiles::new(&base, "test_buildler");
             let mut builder = files.new_file_builder(11233).await.unwrap();
             builder.add_delete_pages(&[1, 2]);
             builder.add_page(3, 1, &[3, 4, 1]).await.unwrap();
@@ -139,7 +141,7 @@ pub(crate) mod facade {
         fn test_test_simple_write_reader() {
             let files = {
                 let base = std::env::temp_dir();
-                PageFiles::new(&base, "testdata")
+                PageFiles::new(&base, "test_simple_rw")
             };
 
             let file_id = 2;
@@ -178,6 +180,86 @@ pub(crate) mod facade {
 
                 let delete_tables = reader.read_delete_pages().await.unwrap();
                 assert_eq!(delete_tables.len(), 2);
+            }
+        }
+
+        #[photonio::test]
+        fn test_file_info_recovery_and_add_new_file() {
+            let files = {
+                let base = std::env::temp_dir();
+                PageFiles::new(&base, "test_recovery")
+            };
+
+            let info_builder = files.new_info_builder();
+
+            {
+                // test add new files.
+                let mut mock_version = HashMap::new();
+                {
+                    let file_id = 1;
+                    let mut b = files.new_file_builder(file_id).await.unwrap();
+                    b.add_page(1, page_addr(file_id, 0), &[1].repeat(10))
+                        .await
+                        .unwrap();
+                    b.add_page(2, page_addr(file_id, 1), &[2].repeat(10))
+                        .await
+                        .unwrap();
+                    b.add_page(3, page_addr(file_id, 2), &[3].repeat(10))
+                        .await
+                        .unwrap();
+                    let file_info = b.finish().await.unwrap();
+                    mock_version.insert(file_id, file_info);
+                }
+
+                {
+                    let file_id = 2;
+                    let delete_pages = &[page_addr(1, 0)];
+
+                    let mut b = files.new_file_builder(file_id).await.unwrap();
+                    b.add_page(4, page_addr(file_id, 0), &[1].repeat(10))
+                        .await
+                        .unwrap();
+                    b.add_page(5, page_addr(file_id, 1), &[2].repeat(10))
+                        .await
+                        .unwrap();
+                    b.add_page(6, page_addr(file_id, 4), &[3].repeat(10))
+                        .await
+                        .unwrap();
+                    b.add_delete_pages(delete_pages);
+                    let file_info = b.finish().await.unwrap();
+
+                    let file1_before_add = mock_version.get(&1).unwrap().effective_size();
+                    mock_version = info_builder
+                        .add_file_info(&mock_version, file_info, delete_pages)
+                        .unwrap();
+
+                    let file1 = mock_version.get(&1).unwrap();
+                    assert_eq!(file1.effective_size(), file1_before_add - 10);
+                    assert!(file1.get_page_handle(page_addr(1, 0)).is_none());
+                    assert!(file1.get_page_handle(page_addr(1, 1)).is_some());
+                    let file2 = mock_version.get(&2).unwrap();
+                    let hd = file2.get_page_handle(page_addr(2, 4)).unwrap();
+                    assert_eq!(hd.size, 10);
+                    assert_eq!(hd.offset, 20);
+                }
+            }
+
+            {
+                // test recovery file_info from folder.
+                let known_files = &[1, 2];
+                let recovery_mock_version = info_builder
+                    .recovery_base_file_infos(known_files)
+                    .await
+                    .unwrap();
+                let file1 = recovery_mock_version.get(&1).unwrap();
+                assert_eq!(file1.effective_size(), 20);
+                assert!(file1.get_page_handle(page_addr(1, 0)).is_none());
+                let file2 = recovery_mock_version.get(&2).unwrap();
+                assert_eq!(file2.effective_size(), 30);
+                let file2 = recovery_mock_version.get(&2).unwrap();
+                let hd = file2.get_page_handle(page_addr(2, 4)).unwrap();
+                assert_eq!(hd.size, 10);
+                assert_eq!(hd.offset, 20);
             }
         }
 

--- a/src/page_store/page_file/types.rs
+++ b/src/page_store/page_file/types.rs
@@ -1,9 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::{
-    page,
-    page_store::{Error, Result},
-};
+use crate::page_store::{Error, Result};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PageHandle {
@@ -69,6 +66,7 @@ impl FileInfo {
         self.active_pages.contains(index)
     }
 
+    #[inline]
     pub(crate) fn effective_size(&self) -> u32 {
         self.active_size as u32
     }
@@ -80,22 +78,15 @@ impl FileInfo {
 
 pub(crate) struct FileMeta {
     file_id: u32,
-    file_size: u32,
 
     data_offsets: BTreeMap<u64, u64>, // TODO: reduce this size.
     meta_indexes: Vec<u64>,           // [0] -> page_table, [1] ->  delete page, [2], meta_bloc_end
 }
 
 impl FileMeta {
-    pub(crate) fn new(
-        file_id: u32,
-        file_size: u32,
-        indexes: Vec<u64>,
-        offsets: BTreeMap<u64, u64>,
-    ) -> Self {
+    pub(crate) fn new(file_id: u32, indexes: Vec<u64>, offsets: BTreeMap<u64, u64>) -> Self {
         Self {
             file_id,
-            file_size,
             meta_indexes: indexes,
             data_offsets: offsets,
         }
@@ -125,6 +116,7 @@ impl FileMeta {
     }
 
     // Return the total page size(include inactive page).
+    #[inline]
     pub(crate) fn total_page_size(&self) -> usize {
         (**self.meta_indexes.first().as_ref().unwrap()) as usize
     }


### PR DESCRIPTION
closes #67

- return file_info when file_builder::finish() to avoid addition disk read
- test recovery from folder and fix bug