### PR TITLE
Decouple tree operations from the page store

### DIFF
--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -3,7 +3,7 @@ use std::{path::Path, sync::Arc};
 use crate::{
     env::Env,
     page::{Key, Value},
-    page_store::{Error, JobHandle, MinDeclineRateStrategyBuilder, PageStore, RewritePage},
+    page_store::{Error, JobHandle, MinDeclineRateStrategyBuilder, PageStore},
     Result,
 };
 
@@ -16,29 +16,29 @@ mod stats;
 use stats::AtomicStats;
 pub(crate) use stats::Stats;
 
-mod tree_txn;
-use tree_txn::TreeTxn;
+mod tree;
+use tree::Tree;
 
 pub struct Table<E: Env> {
-    tree: Arc<Tree<E>>,
+    tree: Arc<Tree>,
+    store: PageStore<E>,
     _job_guard: JobHandle,
 }
 
 impl<E: Env + 'static> Table<E> {
     /// Opens a tree in the path.
     pub async fn open<P: AsRef<Path>>(env: E, path: P, options: Options) -> Result<Self> {
-        let stats = AtomicStats::default();
-        let store = PageStore::open(env, path, options.page_store.clone()).await?;
-        let tree = Arc::new(Tree {
-            options,
-            stats,
-            store,
-        });
+        let tree = Arc::new(Tree::new(options.clone()));
+        let store = PageStore::open(env, path, options.page_store).await?;
         let rewriter = Box::new(tree.clone());
         // TODO: add options.
         let strategy_builder = Box::new(MinDeclineRateStrategyBuilder::new(1 << 30, usize::MAX));
-        let _job_guard = JobHandle::new(&tree.store, rewriter, strategy_builder);
-        Ok(Self { tree, _job_guard })
+        let _job_guard = JobHandle::new(&store, rewriter, strategy_builder);
+        Ok(Self {
+            tree,
+            store,
+            _job_guard,
+        })
     }
 
     /// Gets the value corresponding to the key and applies the function to it.
@@ -47,88 +47,57 @@ impl<E: Env + 'static> Table<E> {
         F: FnOnce(Option<&[u8]>) -> R,
     {
         let key = Key::new(key, lsn);
-        self.tree.get(key, f).await
+        loop {
+            let guard = self.store.guard();
+            let session = self.tree.begin(&guard);
+            match session.get(key).await {
+                Ok(value) => {
+                    self.tree.stats.success.get.inc();
+                    return Ok(f(value));
+                }
+                Err(Error::Again) => {
+                    self.tree.stats.restart.get.inc();
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
     }
 
     pub async fn put(&self, key: &[u8], lsn: u64, value: &[u8]) -> Result<()> {
         let key = Key::new(key, lsn);
         let value = Value::Put(value);
-        self.tree.write(key, value).await?;
+        self.write(key, value).await?;
         Ok(())
     }
 
     pub async fn delete(&self, key: &[u8], lsn: u64) -> Result<()> {
         let key = Key::new(key, lsn);
         let value = Value::Delete;
-        self.tree.write(key, value).await?;
+        self.write(key, value).await?;
         Ok(())
-    }
-
-    /// Returns the statistics of the tree.
-    pub fn stats(&self) -> Stats {
-        self.tree.stats.snapshot()
-    }
-}
-
-struct Tree<E: Env> {
-    options: Options,
-    stats: AtomicStats,
-    store: PageStore<E>,
-}
-
-impl<E: Env + 'static> Tree<E> {
-    fn begin(&self) -> TreeTxn<E> {
-        TreeTxn::new(self)
-    }
-
-    async fn get<F, R>(&self, key: Key<'_>, f: F) -> Result<R>
-    where
-        F: FnOnce(Option<&[u8]>) -> R,
-    {
-        loop {
-            let txn = self.begin();
-            match txn.get(key).await {
-                Ok(value) => {
-                    self.stats.success.get.inc();
-                    return Ok(f(value));
-                }
-                Err(Error::Again) => {
-                    self.stats.restart.get.inc();
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
     }
 
     async fn write(&self, key: Key<'_>, value: Value<'_>) -> Result<()> {
         loop {
-            let txn = self.begin();
-            match txn.write(key, value).await {
+            let guard = self.store.guard();
+            let session = self.tree.begin(&guard);
+            match session.write(key, value).await {
                 Ok(_) => {
-                    self.stats.success.write.inc();
+                    self.tree.stats.success.write.inc();
                     return Ok(());
                 }
                 Err(Error::Again) => {
-                    self.stats.restart.write.inc();
+                    self.tree.stats.restart.write.inc();
                     continue;
                 }
                 Err(e) => return Err(e.into()),
             }
         }
     }
-}
 
-#[async_trait::async_trait]
-impl<E: Env + 'static> RewritePage for Arc<Tree<E>> {
-    async fn rewrite(&self, page_id: u64) -> crate::page_store::Result<()> {
-        loop {
-            let txn = self.begin();
-            match txn.rewrite_page(page_id).await {
-                Ok(_) => return Ok(()),
-                Err(Error::Again) => continue,
-                Err(e) => return Err(e),
-            }
-        }
+    /// Returns the statistics of the table.
+    pub fn stats(&self) -> Stats {
+        self.tree.stats.snapshot()
     }
 }


### PR DESCRIPTION
The benefit is that we can now create a `PageRewriter` before creating a `PageStore`.