### PR TITLE
page_store: remove OpenOption::append and PositionalReader::sync_all

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -9,15 +9,6 @@ pub use stdenv::Std;
 mod photon;
 pub use photon::Photon;
 
-///  Options to configure how the file is written.
-// TODO: remove this after make manifest always open new file when restarting.
-#[derive(Default)]
-pub struct WriteOptions {
-    /// Sets the option for the append mode.
-    /// See also [`std::fs::OpenOptions::append`].
-    pub append: bool,
-}
-
 /// Provides an environment to interact with a specific platform.
 #[async_trait]
 pub trait Env: Clone + Send + Sync + 'static {
@@ -31,11 +22,7 @@ pub trait Env: Clone + Send + Sync + 'static {
         P: AsRef<Path> + Send;
 
     /// Opens a file for sequential writes.
-    async fn open_sequential_writer<P>(
-        &self,
-        path: P,
-        opt: WriteOptions,
-    ) -> Result<Self::SequentialWriter>
+    async fn open_sequential_writer<P>(&self, path: P) -> Result<Self::SequentialWriter>
     where
         P: AsRef<Path> + Send;
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -136,6 +136,9 @@ pub trait SequentialWriter: Send + Sync + 'static {
     /// Returns Ok when success.
     async fn sync_data(&mut self) -> Result<()>;
 
+    /// Returns Ok when success.
+    async fn sync_all(&mut self) -> Result<()>;
+
     /// Truncate the writtern file to a specified length.
     async fn truncate(&self, len: u64) -> Result<()>;
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -15,6 +15,7 @@ pub trait Env: Clone + Send + Sync + 'static {
     type PositionalReader: PositionalReader;
     type SequentialWriter: SequentialWriter;
     type JoinHandle<T: Send>: Future<Output = T> + Send;
+    type Directory: Directory + Send + Sync + 'static;
 
     /// Opens a file for positional reads.
     async fn open_positional_reader<P>(&self, path: P) -> Result<Self::PositionalReader>
@@ -61,6 +62,9 @@ pub trait Env: Clone + Send + Sync + 'static {
     /// directory, etc.
     /// See alos [`std::fs::metadata`].
     async fn metadata<P: AsRef<Path> + Send>(&self, path: P) -> Result<Metadata>;
+
+    // Open the directory.
+    async fn open_dir<P: AsRef<Path> + Send>(&self, path: P) -> Result<Self::Directory>;
 }
 
 #[async_trait]
@@ -74,10 +78,6 @@ pub trait PositionalReader: Send + Sync + 'static {
     ///
     /// Returns the number of bytes read.
     fn read_at<'a>(&'a self, buf: &'a mut [u8], pos: u64) -> Self::ReadAt<'a>;
-
-    /// Synchronizes all modified data (include metadata) this file to disk.
-    /// For reader, it's normally used to sync on folder.
-    async fn sync_all(&mut self) -> Result<()>;
 
     /// Enable direct_io for the reader.
     /// return error if direct_io unsupported.
@@ -135,11 +135,6 @@ pub trait SequentialWriter: Send + Sync + 'static {
     ///
     /// Returns Ok when success.
     async fn sync_data(&mut self) -> Result<()>;
-
-    ///  Synchronizes all modified data (include metadata) this file to disk.
-    ///
-    /// Returns Ok when success.
-    async fn sync_all(&mut self) -> Result<()>;
 
     /// Truncate the writtern file to a specified length.
     async fn truncate(&self, len: u64) -> Result<()>;
@@ -217,4 +212,10 @@ pub(in crate::env) fn direct_io_ify(_: i32) -> Result<()> {
         std::io::ErrorKind::Unsupported,
         "enable direct io fail",
     ))
+}
+
+#[async_trait]
+pub trait Directory {
+    // Sync_all directory.
+    async fn sync_all(&self) -> Result<()>;
 }

--- a/src/env/photon.rs
+++ b/src/env/photon.rs
@@ -109,9 +109,13 @@ impl super::SequentialWriter for SequentialWriter {
         self.0.write(buf)
     }
 
+    // TODO: sync range(sync start->current => sync last_offset->current)
     async fn sync_data(&mut self) -> Result<()> {
-        // TODO: sync range(sync start->current => sync last_offset->current)
         self.0.sync_data().await
+    }
+
+    async fn sync_all(&mut self) -> Result<()> {
+        self.0.sync_all().await
     }
 
     async fn truncate(&self, len: u64) -> Result<()> {

--- a/src/env/photon.rs
+++ b/src/env/photon.rs
@@ -34,30 +34,18 @@ impl Env for Photon {
         Ok(PositionalReader(r))
     }
 
-    async fn open_sequential_writer<P>(
-        &self,
-        path: P,
-        opt: WriteOptions,
-    ) -> Result<Self::SequentialWriter>
+    async fn open_sequential_writer<P>(&self, path: P) -> Result<Self::SequentialWriter>
     where
         P: AsRef<Path> + Send,
     {
-        let w = if opt.append {
-            OpenOptions::new()
-                .write(true)
-                .create(true)
-                .append(true)
-                .open(path)
-                .await
-        } else {
+        Ok(SequentialWriter(
             OpenOptions::new()
                 .write(true)
                 .create(true)
                 .truncate(true)
                 .open(path)
-                .await
-        }?;
-        Ok(SequentialWriter(w))
+                .await?,
+        ))
     }
 
     fn spawn_background<F>(&self, f: F) -> JoinHandle<F::Output>

--- a/src/env/photon.rs
+++ b/src/env/photon.rs
@@ -8,10 +8,7 @@ use std::{
 };
 
 use futures::FutureExt;
-use photonio::{
-    fs::{File, OpenOptions},
-    task,
-};
+use photonio::{fs::File, task};
 
 use super::*;
 
@@ -29,23 +26,14 @@ impl Env for Photon {
     where
         P: AsRef<Path> + Send,
     {
-        let path = path.as_ref();
-        let r = OpenOptions::new().read(true).open(path).await?;
-        Ok(PositionalReader(r))
+        Ok(PositionalReader(File::open(path).await?))
     }
 
     async fn open_sequential_writer<P>(&self, path: P) -> Result<Self::SequentialWriter>
     where
         P: AsRef<Path> + Send,
     {
-        Ok(SequentialWriter(
-            OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(path)
-                .await?,
-        ))
+        Ok(SequentialWriter(File::create(path).await?))
     }
 
     fn spawn_background<F>(&self, f: F) -> JoinHandle<F::Output>

--- a/src/env/stdenv.rs
+++ b/src/env/stdenv.rs
@@ -130,6 +130,10 @@ impl super::SequentialWriter for SequentialWriter {
         async move { self.0.sync_data() }.await
     }
 
+    async fn sync_all(&mut self) -> Result<()> {
+        async move { self.0.sync_all() }.await
+    }
+
     async fn truncate(&self, len: u64) -> Result<()> {
         async move { self.0.set_len(len) }.await
     }

--- a/src/env/stdenv.rs
+++ b/src/env/stdenv.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{File, OpenOptions},
+    fs::File,
     future::Future,
     io::Result,
     os::fd::AsRawFd,
@@ -27,21 +27,14 @@ impl Env for Std {
     where
         P: AsRef<Path> + Send,
     {
-        let file = OpenOptions::new().read(true).open(path.as_ref())?;
-        Ok(PositionalReader(file))
+        Ok(PositionalReader(File::open(path)?))
     }
 
     async fn open_sequential_writer<P>(&self, path: P) -> Result<Self::SequentialWriter>
     where
         P: AsRef<Path> + Send,
     {
-        Ok(SequentialWriter(
-            OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(path.as_ref())?,
-        ))
+        Ok(SequentialWriter(File::create(path)?))
     }
 
     fn spawn_background<F>(&self, f: F) -> JoinHandle<F::Output>

--- a/src/env/stdenv.rs
+++ b/src/env/stdenv.rs
@@ -31,28 +31,17 @@ impl Env for Std {
         Ok(PositionalReader(file))
     }
 
-    async fn open_sequential_writer<P>(
-        &self,
-        path: P,
-        opt: WriteOptions,
-    ) -> Result<Self::SequentialWriter>
+    async fn open_sequential_writer<P>(&self, path: P) -> Result<Self::SequentialWriter>
     where
         P: AsRef<Path> + Send,
     {
-        let file = if opt.append {
-            OpenOptions::new()
-                .write(true)
-                .create(true)
-                .append(true)
-                .open(path.as_ref())?
-        } else {
+        Ok(SequentialWriter(
             OpenOptions::new()
                 .write(true)
                 .create(true)
                 .truncate(true)
-                .open(path.as_ref())?
-        };
-        Ok(SequentialWriter(file))
+                .open(path.as_ref())?,
+        ))
     }
 
     fn spawn_background<F>(&self, f: F) -> JoinHandle<F::Output>

--- a/src/page_store/manifest.rs
+++ b/src/page_store/manifest.rs
@@ -134,6 +134,11 @@ impl<E: Env> Manifest<E> {
         } as u64;
 
         if rolled_path.is_some() {
+            current
+                .current_writer
+                .sync_all()
+                .await
+                .expect("sync new manifest file fail");
             self.set_current(file_num).await?;
             // TODO: notify cleaner previous manifest + size, so it can be delete when need.
             self.current_file_num = Some(file_num);
@@ -214,6 +219,10 @@ impl<E: Env> Manifest<E> {
                     .write_all(&file_num.to_le_bytes())
                     .await
                     .expect("write file_num to tmp fail");
+                tmp_file
+                    .sync_all()
+                    .await
+                    .expect("sync tmp current file fail");
             }
 
             match self

--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -528,7 +528,8 @@ impl<'a, E: Env> BufferedWriter<'a, E> {
                 .expect("set set file len fail");
         }
         // panic when sync fail, https://wiki.postgresql.org/wiki/Fsync_Errors
-        self.base_dir.sync_all().await.expect("sync file fail");
+        self.file.sync_all().await.expect("sync file fail");
+        self.base_dir.sync_all().await.expect("sync base dir fail");
         Ok(())
     }
 }

--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -601,7 +601,7 @@ mod tests {
     #[cfg(unix)]
     #[photonio::test]
     async fn test_buffered_writer() {
-        use crate::env::{PositionalReaderExt, WriteOptions};
+        use crate::env::PositionalReaderExt;
 
         let env = crate::env::Photon;
 
@@ -609,7 +609,7 @@ mod tests {
         let path1 = std::env::temp_dir().join("buf_test1");
         {
             let file1 = env
-                .open_sequential_writer(path1.to_owned(), WriteOptions::default())
+                .open_sequential_writer(path1.to_owned())
                 .await
                 .expect("open file_id: {file_id}'s file fail");
             let mut bw1 = BufferedWriter::new(file1, 4096 + 1, use_direct, 512);

--- a/src/page_store/page_file/mod.rs
+++ b/src/page_store/page_file/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod facade {
 
     use super::{file_builder::DEFAULT_BLOCK_SIZE, file_reader::MetaReader, *};
     use crate::{
-        env::{Env, PositionalReader, SequentialWriter, WriteOptions},
+        env::{Env, PositionalReader, SequentialWriter},
         page_store::Result,
     };
 
@@ -51,7 +51,7 @@ pub(crate) mod facade {
             let path = self.base.join(format!("{}_{file_id}", self.file_prefix));
             let writer = self
                 .env
-                .open_sequential_writer(path.to_owned(), WriteOptions::default())
+                .open_sequential_writer(path.to_owned())
                 .await
                 .expect("open reader for file_id: {file_id} fail");
             let use_direct = self.use_direct && writer.direct_io_ify().is_ok();

--- a/src/page_store/page_file/mod.rs
+++ b/src/page_store/page_file/mod.rs
@@ -47,10 +47,7 @@ pub(crate) mod facade {
         }
 
         /// Create file_builder to write a new page_file.
-        pub(crate) async fn new_file_builder(
-            &self,
-            file_id: u32,
-        ) -> Result<FileBuilder<E::SequentialWriter, E::Directory>> {
+        pub(crate) async fn new_file_builder(&self, file_id: u32) -> Result<FileBuilder<E>> {
             // TODO: switch to env in suitable time.
             let path = self.base.join(format!("{}_{file_id}", self.file_prefix));
             let writer = self

--- a/src/page_store/page_txn.rs
+++ b/src/page_store/page_txn.rs
@@ -347,12 +347,12 @@ mod tests {
         Arc::new(Version::new(size, 1, HashMap::default(), HashSet::new()))
     }
 
-    #[test]
-    fn page_txn_update_page() {
+    #[photonio::test]
+    async fn page_txn_update_page() {
         let env = crate::env::Photon;
         let files = {
             let base = std::env::temp_dir();
-            Arc::new(PageFiles::new(env, &base, "test_page_txn_update_page"))
+            Arc::new(PageFiles::new(env, &base, "test_page_txn_update_page").await)
         };
 
         let version = new_version(512);
@@ -365,16 +365,12 @@ mod tests {
         assert!(page_txn.update_page(id, addr, new).is_ok());
     }
 
-    #[test]
-    fn page_txn_failed_update_page() {
+    #[photonio::test]
+    async fn page_txn_failed_update_page() {
         let env = crate::env::Photon;
         let files = {
             let base = std::env::temp_dir();
-            Arc::new(PageFiles::new(
-                env,
-                &base,
-                "test_page_txn_failed_update_page",
-            ))
+            Arc::new(PageFiles::new(env, &base, "test_page_txn_failed_update_page").await)
         };
 
         let version = new_version(1 << 10);
@@ -394,16 +390,12 @@ mod tests {
         assert!(page_txn.update_page(id, 1, addr).is_err());
     }
 
-    #[test]
-    fn page_txn_increment_page_addr_update() {
+    #[photonio::test]
+    async fn page_txn_increment_page_addr_update() {
         let env = crate::env::Photon;
         let files = {
             let base = std::env::temp_dir();
-            Arc::new(PageFiles::new(
-                env,
-                &base,
-                "test_page_increment_page_addr_update",
-            ))
+            Arc::new(PageFiles::new(env, &base, "test_page_increment_page_addr_update").await)
         };
 
         let version = new_version(512);
@@ -413,12 +405,12 @@ mod tests {
         assert!(matches!(page_txn.update_page(1, 3, 2), Err(None)));
     }
 
-    #[test]
-    fn page_txn_replace_page() {
+    #[photonio::test]
+    async fn page_txn_replace_page() {
         let env = crate::env::Photon;
         let files = {
             let base = std::env::temp_dir();
-            Arc::new(PageFiles::new(env, &base, "test_page_txn_replace_page"))
+            Arc::new(PageFiles::new(env, &base, "test_page_txn_replace_page").await)
         };
 
         let version = new_version(1 << 10);
@@ -431,12 +423,12 @@ mod tests {
         assert!(page_txn.replace_page(id, addr, new, &[1, 2, 3]).is_ok());
     }
 
-    #[test]
-    fn page_txn_seal_write_buffer() {
+    #[photonio::test]
+    async fn page_txn_seal_write_buffer() {
         let env = crate::env::Photon;
         let files = {
             let base = std::env::temp_dir();
-            Arc::new(PageFiles::new(env, &base, "test_page_seal_write_buffer"))
+            Arc::new(PageFiles::new(env, &base, "test_page_seal_write_buffer").await)
         };
 
         let version = new_version(512);
@@ -446,12 +438,12 @@ mod tests {
         page_txn.seal_write_buffer();
     }
 
-    #[test]
-    fn page_txn_insert_page() {
+    #[photonio::test]
+    async fn page_txn_insert_page() {
         let env = crate::env::Photon;
         let files = {
             let base = std::env::temp_dir();
-            Arc::new(PageFiles::new(env, &base, "test_page_insert_page"))
+            Arc::new(PageFiles::new(env, &base, "test_page_insert_page").await)
         };
 
         let version = new_version(512);

--- a/src/page_store/recover.rs
+++ b/src/page_store/recover.rs
@@ -26,7 +26,7 @@ impl<E: Env> PageStore<E> {
         let versions = manifest.list_versions().await?;
         let summary = Self::apply_version_edits(versions);
 
-        let page_files = PageFiles::new(env, path.as_ref(), "db");
+        let page_files = PageFiles::new(env, path.as_ref(), "db").await;
         let file_infos = Self::recover_file_infos(&page_files, &summary.active_files).await?;
         let page_table = Self::recover_page_table(&page_files, &summary.active_files).await?;
 


### PR DESCRIPTION
closes #153

- switch current manifest to new file during restart to avoid open-as-append
- add open_dir and cache parent directory to sync file metadata change