### PR TITLE
tree: use "node" instead of "page" in iterator related code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod error;
 pub use error::{Error, Result};
 
 mod tree;
-pub use tree::{Options as TableOptions, NodeIterWithLsn, ReadOptions, Stats, WriteOptions};
+pub use tree::{NodeIterWithLsn, Options as TableOptions, ReadOptions, Stats, WriteOptions};
 
 mod page_store;
 pub use page_store::Options as PageStoreOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod error;
 pub use error::{Error, Result};
 
 mod tree;
-pub use tree::{Options as TableOptions, PageIter, ReadOptions, Stats, WriteOptions};
+pub use tree::{Options as TableOptions, NodeIterWithLsn, ReadOptions, Stats, WriteOptions};
 
 mod page_store;
 pub use page_store::Options as PageStoreOptions;
@@ -92,10 +92,10 @@ mod tests {
         }
 
         let guard = table.pin();
-        let mut pages = guard.pages();
+        let mut nodes = guard.nodes_iter();
         let mut i = 0u64;
-        while let Some(page) = pages.next().await.unwrap() {
-            for (k, v) in page {
+        while let Some(node) = nodes.next().await.unwrap() {
+            for (k, v) in node {
                 assert_eq!(k, &i.to_be_bytes());
                 assert_eq!(v, &i.to_be_bytes());
                 i += 1;

--- a/src/page_store/jobs/gc.rs
+++ b/src/page_store/jobs/gc.rs
@@ -13,19 +13,19 @@ use crate::{
 };
 
 /// Rewrites pages to reclaim disk space.
-pub(crate) trait RewritePage<E: Env>: Send + Sync + 'static {
+pub(crate) trait RewritePageChain<E: Env>: Send + Sync + 'static {
     type Rewrite<'a>: Future<Output = Result<()>> + Send + 'a
     where
         Self: 'a;
 
     /// Rewrites the corresponding page to reclaim the space it occupied.
-    fn rewrite<'a>(&'a self, page_id: u64, guard: Guard<'a, E>) -> Self::Rewrite<'a>;
+    fn rewrite<'a>(&'a self, node_id: u64, guard: Guard<'a, E>) -> Self::Rewrite<'a>;
 }
 
 pub(crate) struct GcCtx<E, R>
 where
     E: Env,
-    R: RewritePage<E>,
+    R: RewritePageChain<E>,
 {
     shutdown: Shutdown,
 
@@ -41,7 +41,7 @@ where
 impl<E, R> GcCtx<E, R>
 where
     E: Env,
-    R: RewritePage<E>,
+    R: RewritePageChain<E>,
 {
     pub(crate) fn new(
         shutdown: Shutdown,

--- a/src/page_store/jobs/mod.rs
+++ b/src/page_store/jobs/mod.rs
@@ -3,4 +3,4 @@
 pub(crate) mod cleanup;
 pub(crate) mod flush;
 pub(crate) mod gc;
-pub(crate) use gc::RewritePage;
+pub(crate) use gc::RewritePageChain;

--- a/src/page_store/mod.rs
+++ b/src/page_store/mod.rs
@@ -20,7 +20,7 @@ mod version;
 use version::{Version, VersionOwner};
 
 mod jobs;
-pub(crate) use jobs::RewritePage;
+pub(crate) use jobs::RewritePageChain;
 use jobs::{cleanup::CleanupCtx, flush::FlushCtx, gc::GcCtx};
 
 mod write_buffer;
@@ -74,7 +74,7 @@ impl<E: Env> PageStore<E> {
     pub(crate) async fn open<P, R>(env: E, path: P, options: Options, rewriter: R) -> Result<Self>
     where
         P: AsRef<Path>,
-        R: RewritePage<E>,
+        R: RewritePageChain<E>,
     {
         let (next_file_id, manifest, table, page_files, file_infos) =
             Self::recover(env.to_owned(), path).await?;
@@ -147,7 +147,7 @@ impl<E: Env> PageStore<E> {
 
     fn spawn_gc_job<R>(&mut self, rewriter: R)
     where
-        R: RewritePage<E>,
+        R: RewritePageChain<E>,
     {
         let strategy_builder = Box::new(MinDeclineRateStrategyBuilder::new(1 << 30, usize::MAX));
         let job = GcCtx::new(

--- a/src/photon.rs
+++ b/src/photon.rs
@@ -52,4 +52,4 @@ impl Deref for Table {
 pub type Guard<'a> = raw::Guard<'a, Photon>;
 
 /// An iterator over pages in a table.
-pub type Pages<'a, 't> = raw::Pages<'a, 't, Photon>;
+pub type Pages<'a, 't> = raw::NodesIter<'a, 't, Photon>;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -4,4 +4,4 @@ mod store;
 pub use store::Store;
 
 mod table;
-pub use table::{Guard, Pages, Table};
+pub use table::{Guard, NodesIter, Table};

--- a/src/raw/table.rs
+++ b/src/raw/table.rs
@@ -135,18 +135,18 @@ impl<'a, E: Env> Guard<'a, E> {
         Ok(self.txn.get(key).await?)
     }
 
-    /// Returns an iterator over pages in the table.
-    pub fn pages(&self) -> Pages<'_, 'a, E> {
-        Pages::new(&self.txn)
+    /// Returns an iterator over nodes in the table.
+    pub fn nodes_iter(&self) -> NodesIter<'_, 'a, E> {
+        NodesIter::new(&self.txn)
     }
 }
 
-/// An iterator over pages in a table.
-pub struct Pages<'a, 't: 'a, E: Env> {
+/// An iterator over nodes in a table.
+pub struct NodesIter<'a, 't: 'a, E: Env> {
     iter: TreeIter<'a, 't, E>,
 }
 
-impl<'a, 't: 'a, E: Env> Pages<'a, 't, E> {
+impl<'a, 't: 'a, E: Env> NodesIter<'a, 't, E> {
     fn new(txn: &'a TreeTxn<'t, E>) -> Self {
         Self {
             iter: TreeIter::new(txn, ReadOptions::default()),
@@ -154,7 +154,7 @@ impl<'a, 't: 'a, E: Env> Pages<'a, 't, E> {
     }
 
     /// Returns the next page in the table.
-    pub async fn next(&mut self) -> Result<Option<PageIter<'_>>> {
-        Ok(self.iter.next_page().await?)
+    pub async fn next(&mut self) -> Result<Option<NodeIterWithLsn<'_>>> {
+        Ok(self.iter.next_node().await?)
     }
 }

--- a/src/std.rs
+++ b/src/std.rs
@@ -86,7 +86,7 @@ impl Deref for Table {
 pub type Guard<'a> = raw::Guard<'a, Std>;
 
 /// An iterator over pages in a table.
-pub type Pages<'a, 't> = raw::Pages<'a, 't, Std>;
+pub type Pages<'a, 't> = raw::NodesIter<'a, 't, Std>;
 
 fn poll<F: Future>(mut future: F) -> F::Output {
     let cx = &mut Context::from_waker(noop_waker_ref());


### PR DESCRIPTION
As part of this refactoring: https://github.com/photondb/photondb/issues/215
This PR introduce "node" related to iteration in the tree.