### PR TITLE
Refactor sorted page split to return left and right iterators

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -388,7 +388,7 @@ impl<'a, E: Env> TreeTxn<'a, E> {
         }
 
         let page = SortedPageRef::<K, V>::from(view.page);
-        if let Some((split_key, right_iter)) = page.into_split_iter() {
+        if let Some((split_key, _, right_iter)) = page.into_split_iter() {
             let mut txn = self.guard.begin();
             // Build and insert the right page.
             let right_id = {


### PR DESCRIPTION
This will be used to fix some problems about root split.