### PR TITLE
*: update photonio version in tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crossbeam-epoch = "0.9.10"
 futures = "0.3.24"
 log = "0.4"
 once_cell = "1.15"
-photonio = { git = "https://github.com/photondb/photonio.git", rev = "b32132b" }
+photonio = { git = "https://github.com/photondb/photonio.git", version = "0.0.5" }
 prost = "0.11"
 thiserror = "1.0.37"
 roaring = "0.10"

--- a/bin/tools/Cargo.toml
+++ b/bin/tools/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "0.9.1"
 futures = "0.3.24"
 log = "0.4.17"
 hdrhistogram = "7.5.2"
-photonio = { git = "https://github.com/photondb/photonio.git" }
+photonio = { git = "https://github.com/photondb/photonio.git", version = "0.0.5" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 thiserror = "1.0.37"
 chrono = "0.4"


### PR DESCRIPTION
The tools using different version cause

```
thread 'photonio-worker/0' panicked at 'cannot access a scoped thread local variable without calling `set` first', /home/robi/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/scoped-tls-1.0.1/src/lib.rs:168:9
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/8ce3204af9463db3192ea1eb31c45c2f6d4b5ae6/library/std/src/panicking.rs:588:12
   1: scoped_tls::ScopedKey<T>::with
             at /home/robi/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/scoped-tls-1.0.1/src/lib.rs:168:9
   2: photonio_uring::runtime::worker::spawn
             at /home/robi/.cargo/git/checkouts/photonio-4d2b22930312944b/b32132b/photonio-uring/src/runtime/worker.rs:163:5
   3: <photondb::env::photon::Photon as photondb::env::Env>::spawn_background
```