### PR TITLE
Avoid changing the id of existing pages on root split

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -438,7 +438,7 @@ impl<'a, E: Env> TreeTxn<'a, E> {
     {
         assert_eq!(view.id, ROOT_ID);
         assert_eq!(view.page.epoch(), 0);
-        assert_eq!(view.page.chain_len(), 0);
+        assert_eq!(view.page.chain_len(), 1);
 
         let page = SortedPageRef::<K, V>::from(view.page);
         let Some((split_key, left_iter, right_iter)) = page.into_split_iter() else {


### PR DESCRIPTION
The underlying page store assumes that the mapping between page addresses and page ids is fixed.

However, the `reconcile_split_root()` will associate the original page chain with another page id. To address this problem, this PR refactors the root split and will not reuse any existing pages anymore.