### PR TITLE
page_store: make `use_direct_io` configurable in options

### DIFF
--- a/photondb/src/lib.rs
+++ b/photondb/src/lib.rs
@@ -64,6 +64,7 @@ mod tests {
         page_chain_length: 2,
         page_store: PageStoreOptions {
             write_buffer_capacity: 1 << 20,
+            use_direct_io: false,
         },
     };
 

--- a/photondb/src/page_store/jobs/flush.rs
+++ b/photondb/src/page_store/jobs/flush.rs
@@ -309,7 +309,7 @@ mod tests {
         FlushCtx {
             shutdown,
             version_owner,
-            page_files: Arc::new(PageFiles::new(Photon, base).await),
+            page_files: Arc::new(PageFiles::new(Photon, base, false).await),
             manifest: Arc::new(futures::lock::Mutex::new(
                 Manifest::open(Photon, base).await.unwrap(),
             )),

--- a/photondb/src/page_store/jobs/gc.rs
+++ b/photondb/src/page_store/jobs/gc.rs
@@ -309,7 +309,7 @@ mod tests {
             rewriter,
             strategy_builder,
             page_table: PageTable::default(),
-            page_files: Arc::new(PageFiles::new(Photon, dir).await),
+            page_files: Arc::new(PageFiles::new(Photon, dir, false).await),
             cleaned_files: HashSet::default(),
         }
     }

--- a/photondb/src/page_store/mod.rs
+++ b/photondb/src/page_store/mod.rs
@@ -44,12 +44,18 @@ pub struct Options {
     ///
     /// Default: 128MB
     pub write_buffer_capacity: u32,
+
+    /// If true, use O_DIRECT to read/write page files.
+    ///
+    /// Default: false
+    pub use_direct_io: bool,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
             write_buffer_capacity: 128 << 20,
+            use_direct_io: false,
         }
     }
 }
@@ -77,7 +83,7 @@ impl<E: Env> PageStore<E> {
         R: RewritePage<E>,
     {
         let (next_file_id, manifest, table, page_files, file_infos) =
-            Self::recover(env.to_owned(), path).await?;
+            Self::recover(env.to_owned(), path, &options).await?;
 
         let version = Version::new(
             options.write_buffer_capacity,

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -52,7 +52,7 @@ pub(crate) mod facade {
     impl<E: Env> PageFiles<E> {
         /// Create page file facade.
         /// It should be a singleton in the page_store.
-        pub(crate) async fn new(env: E, base: impl Into<PathBuf>) -> Self {
+        pub(crate) async fn new(env: E, base: impl Into<PathBuf>, use_direct: bool) -> Self {
             let base = base.into();
             let base_dir = env.open_dir(&base).await.expect("open base dir fail");
             let reader_cache = ReaderCache::new(MAX_OPEN_READER_FD_NUM);
@@ -60,7 +60,7 @@ pub(crate) mod facade {
                 env,
                 base,
                 base_dir,
-                use_direct: true,
+                use_direct,
                 reader_cache,
             }
         }
@@ -186,7 +186,7 @@ pub(crate) mod facade {
         fn test_file_builder() {
             let env = crate::env::Photon;
             let base = TempDir::new("test_builder").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
             let mut builder = files.new_file_builder(11233).await.unwrap();
             builder.add_delete_pages(&[1, 2]);
             builder.add_page(3, 1, &[3, 4, 1]).await.unwrap();
@@ -197,7 +197,7 @@ pub(crate) mod facade {
         fn test_read_page() {
             let env = crate::env::Photon;
             let base = TempDir::new("test_dread").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
             let file_id = 2;
             let info = {
                 let mut b = files.new_file_builder(file_id).await.unwrap();
@@ -256,7 +256,7 @@ pub(crate) mod facade {
         fn test_test_simple_write_reader() {
             let env = crate::env::Photon;
             let base = TempDir::new("test_simple_rw").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
 
             let file_id = 2;
             let ret_info = {
@@ -314,7 +314,7 @@ pub(crate) mod facade {
         fn test_file_info_recovery_and_add_new_file() {
             let env = crate::env::Photon;
             let base = TempDir::new("test_recovery").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
 
             let info_builder = files.new_info_builder();
             {
@@ -394,7 +394,7 @@ pub(crate) mod facade {
         fn test_query_page_id_by_addr() {
             let env = crate::env::Photon;
             let base = TempDir::new("test_query_id_by_addr").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
             let file_id = 1;
             let page_addr1 = page_addr(file_id, 0);
             let page_addr2 = page_addr(file_id, 1);
@@ -422,7 +422,7 @@ pub(crate) mod facade {
         fn test_get_child_page() {
             let env = crate::env::Photon;
             let base = TempDir::new("test_get_child_page").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
             let info_builder = files.new_info_builder();
 
             let file_id = 1;
@@ -456,7 +456,7 @@ pub(crate) mod facade {
 
             let env = crate::env::Photon;
             let base = TempDir::new("test_get_child_page").unwrap();
-            let files = PageFiles::new(env, base.path()).await;
+            let files = PageFiles::new(env, base.path(), true).await;
             new_file(&files, 0).await;
             new_file(&files, 1).await;
             new_file(&files, 3).await;

--- a/photondb/src/page_store/page_txn.rs
+++ b/photondb/src/page_store/page_txn.rs
@@ -363,7 +363,7 @@ mod tests {
     async fn page_txn_update_page() {
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_txn_update_page").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
         let version = new_version(512);
         let page_table = PageTable::default();
         let guard = Guard::new(version.clone(), &page_table, &files);
@@ -380,7 +380,7 @@ mod tests {
     async fn page_txn_failed_update_page() {
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_txn_failed_update_page").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
 
         let version = new_version(1 << 10);
         let page_table = PageTable::default();
@@ -405,7 +405,7 @@ mod tests {
     async fn page_txn_increment_page_addr_update() {
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_increment_page_addr_update").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
 
         let version = new_version(512);
         let page_table = PageTable::default();
@@ -418,7 +418,7 @@ mod tests {
     async fn page_txn_replace_page() {
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_txn_replace_page").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
 
         let version = new_version(1 << 10);
         let page_table = PageTable::default();
@@ -436,7 +436,7 @@ mod tests {
     async fn page_txn_seal_write_buffer() {
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_seal_write_buffer").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
 
         let version = new_version(512);
         let page_table = PageTable::default();
@@ -449,7 +449,7 @@ mod tests {
     async fn page_txn_seal_write_buffer_twice() {
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_seal_write_buffer_twice").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
 
         let version = new_version(512);
         let page_table = PageTable::default();
@@ -465,7 +465,7 @@ mod tests {
         env_logger::init();
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_insert_page").unwrap();
-        let files = Arc::new(PageFiles::new(env, base.path()).await);
+        let files = Arc::new(PageFiles::new(env, base.path(), false).await);
 
         let version = new_version(512);
         let page_table = PageTable::default();

--- a/photondb/src/page_store/recover.rs
+++ b/photondb/src/page_store/recover.rs
@@ -15,6 +15,7 @@ impl<E: Env> PageStore<E> {
     pub(super) async fn recover<P: AsRef<Path>>(
         env: E,
         path: P,
+        options: &crate::PageStoreOptions,
     ) -> Result<(
         u32, /* next file id */
         Manifest<E>,
@@ -26,7 +27,7 @@ impl<E: Env> PageStore<E> {
         let versions = manifest.list_versions().await?;
         let summary = Self::apply_version_edits(versions);
 
-        let page_files = PageFiles::new(env, path.as_ref()).await;
+        let page_files = PageFiles::new(env, path.as_ref(), options.use_direct_io).await;
         let file_infos = Self::recover_file_infos(&page_files, &summary.active_files).await?;
         let page_table = Self::recover_page_table(&page_files, &summary.active_files).await?;
 


### PR DESCRIPTION
fixes #175

due to #175, it's better disable direct_io as default