### PR TITLE
delete reference in Guard

### DIFF
--- a/photondb/src/page_store/jobs/reclaim.rs
+++ b/photondb/src/page_store/jobs/reclaim.rs
@@ -23,7 +23,7 @@ pub(crate) trait RewritePage<E: Env>: Send + Sync + 'static {
         Self: 'a;
 
     /// Rewrites the corresponding page to reclaim the space it occupied.
-    fn rewrite(&'_ self, page_id: u64, guard: Guard<E>) -> Self::Rewrite<'_>;
+    fn rewrite(&self, page_id: u64, guard: Guard<E>) -> Self::Rewrite<'_>;
 }
 
 pub(crate) struct ReclaimCtx<E, R>
@@ -383,7 +383,7 @@ mod tests {
         where
             Self: 'a;
 
-        fn rewrite(&'_ self, id: u64, _guard: Guard<Photon>) -> Self::Rewrite<'_> {
+        fn rewrite(&self, id: u64, _guard: Guard<Photon>) -> Self::Rewrite<'_> {
             self.values.lock().unwrap().push(id);
             async { Ok(()) }
         }

--- a/photondb/src/page_store/jobs/reclaim.rs
+++ b/photondb/src/page_store/jobs/reclaim.rs
@@ -23,7 +23,7 @@ pub(crate) trait RewritePage<E: Env>: Send + Sync + 'static {
         Self: 'a;
 
     /// Rewrites the corresponding page to reclaim the space it occupied.
-    fn rewrite<'a>(&'a self, page_id: u64, guard: Guard<'a, E>) -> Self::Rewrite<'a>;
+    fn rewrite(&'_ self, page_id: u64, guard: Guard<E>) -> Self::Rewrite<'_>;
 }
 
 pub(crate) struct ReclaimCtx<E, R>
@@ -202,7 +202,11 @@ where
                 continue;
             }
             rewrite_pages.insert(page_id);
-            let guard = Guard::new(version.clone(), &self.page_table, &self.page_files);
+            let guard = Guard::new(
+                version.clone(),
+                self.page_table.clone(),
+                self.page_files.clone(),
+            );
             self.rewriter.rewrite(page_id, guard).await?;
         }
         Ok(total_rewrite_pages)
@@ -247,7 +251,11 @@ where
         pages: &[u64],
     ) -> Result<()> {
         loop {
-            let guard = Guard::new(version.clone(), &self.page_table, &self.page_files);
+            let guard = Guard::new(
+                version.clone(),
+                self.page_table.clone(),
+                self.page_files.clone(),
+            );
             let txn = guard.begin();
             match txn.dealloc_pages(file_id, pages) {
                 Ok(()) => return Ok(()),
@@ -375,7 +383,7 @@ mod tests {
         where
             Self: 'a;
 
-        fn rewrite<'a>(&'a self, id: u64, _guard: Guard<'a, Photon>) -> Self::Rewrite<'a> {
+        fn rewrite(&'_ self, id: u64, _guard: Guard<Photon>) -> Self::Rewrite<'_> {
             self.values.lock().unwrap().push(id);
             async { Ok(()) }
         }

--- a/photondb/src/page_store/mod.rs
+++ b/photondb/src/page_store/mod.rs
@@ -134,7 +134,7 @@ impl<E: Env> PageStore<E> {
 
     #[inline]
     pub(crate) fn guard(&self) -> Guard<E> {
-        Guard::new(self.version(), &self.table, &self.page_files)
+        Guard::new(self.version(), self.table.clone(), self.page_files.clone())
     }
 
     pub(crate) async fn close(mut self) {

--- a/photondb/src/page_store/page_txn.rs
+++ b/photondb/src/page_store/page_txn.rs
@@ -13,21 +13,21 @@ use crate::{
     page::{PageBuf, PageRef},
 };
 
-pub(crate) struct Guard<'a, E: Env>
+pub(crate) struct Guard<E: Env>
 where
     Self: Send,
 {
     version: Arc<Version>,
-    page_table: &'a PageTable,
-    page_files: &'a PageFiles<E>,
+    page_table: PageTable,
+    page_files: Arc<PageFiles<E>>,
     owned_pages: Mutex<Vec<Vec<u8>>>,
 }
 
-impl<'a, E: Env> Guard<'a, E> {
+impl<E: Env> Guard<E> {
     pub(crate) fn new(
         version: Arc<Version>,
-        page_table: &'a PageTable,
-        page_files: &'a PageFiles<E>,
+        page_table: PageTable,
+        page_files: Arc<PageFiles<E>>,
     ) -> Self {
         Guard {
             version,
@@ -113,7 +113,7 @@ pub(crate) struct PageTxn<'a, E: Env>
 where
     Self: Send,
 {
-    guard: &'a Guard<'a, E>,
+    guard: &'a Guard<E>,
 
     file_id: u32,
     hold_write_guard: bool,
@@ -366,7 +366,7 @@ mod tests {
         let files = Arc::new(PageFiles::new(env, base.path(), false).await);
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), &page_table, &files);
+        let guard = Guard::new(version.clone(), page_table, files);
         let mut page_txn = guard.begin();
         let (addr, _) = page_txn.alloc_page(123).unwrap();
         let id = page_txn.insert_page(addr);
@@ -384,7 +384,7 @@ mod tests {
 
         let version = new_version(1 << 10);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), &page_table, &files);
+        let guard = Guard::new(version.clone(), page_table, files);
 
         // insert old page.
         let mut page_txn = guard.begin();
@@ -409,7 +409,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version, &page_table, &files);
+        let guard = Guard::new(version, page_table, files);
         let page_txn = guard.begin();
         assert!(matches!(page_txn.update_page(1, 3, 2), Err(None)));
     }
@@ -422,7 +422,7 @@ mod tests {
 
         let version = new_version(1 << 10);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), &page_table, &files);
+        let guard = Guard::new(version.clone(), page_table, files);
         let mut page_txn = guard.begin();
         let (addr, _) = page_txn.alloc_page(123).unwrap();
         let id = page_txn.insert_page(addr);
@@ -440,7 +440,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version, &page_table, &files);
+        let guard = Guard::new(version, page_table, files);
         let mut page_txn = guard.begin();
         page_txn.seal_write_buffer();
     }
@@ -453,7 +453,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version, &page_table, &files);
+        let guard = Guard::new(version, page_table, files);
         let mut page_txn_1 = guard.begin();
         let mut page_txn_2 = guard.begin();
         page_txn_1.seal_write_buffer();
@@ -469,7 +469,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), &page_table, &files);
+        let guard = Guard::new(version.clone(), page_table.clone(), files);
         let mut page_txn = guard.begin();
         let (addr, _) = page_txn.alloc_page(123).unwrap();
         let id = page_txn.insert_page(addr);

--- a/photondb/src/tree/mod.rs
+++ b/photondb/src/tree/mod.rs
@@ -37,7 +37,7 @@ impl Tree {
         }
     }
 
-    pub(crate) fn begin<'a, E: Env>(&'a self, guard: Guard<'a, E>) -> TreeTxn<'a, E> {
+    pub(crate) fn begin<E: Env>(&self, guard: Guard<E>) -> TreeTxn<E> {
         TreeTxn::new(self, guard)
     }
 
@@ -81,7 +81,7 @@ impl<E: Env> RewritePage<E> for Arc<Tree> {
         where
             Self: 'a;
 
-    fn rewrite<'a>(&'a self, id: u64, guard: Guard<'a, E>) -> Self::Rewrite<'a> {
+    fn rewrite(&'_ self, id: u64, guard: Guard<E>) -> Self::Rewrite<'_> {
         async move {
             let txn = self.begin(guard);
             txn.rewrite_page(id).await
@@ -91,11 +91,11 @@ impl<E: Env> RewritePage<E> for Arc<Tree> {
 
 pub(crate) struct TreeTxn<'a, E: Env> {
     tree: &'a Tree,
-    guard: Guard<'a, E>,
+    guard: Guard<E>,
 }
 
 impl<'a, E: Env> TreeTxn<'a, E> {
-    fn new(tree: &'a Tree, guard: Guard<'a, E>) -> Self {
+    fn new(tree: &'a Tree, guard: Guard<E>) -> Self {
         Self { tree, guard }
     }
 

--- a/photondb/src/tree/mod.rs
+++ b/photondb/src/tree/mod.rs
@@ -81,7 +81,7 @@ impl<E: Env> RewritePage<E> for Arc<Tree> {
         where
             Self: 'a;
 
-    fn rewrite(&'_ self, id: u64, guard: Guard<E>) -> Self::Rewrite<'_> {
+    fn rewrite(&self, id: u64, guard: Guard<E>) -> Self::Rewrite<'_> {
         async move {
             let txn = self.begin(guard);
             txn.rewrite_page(id).await


### PR DESCRIPTION
Iterator in table entries is not easy to solved because of lifetime annotation in the codebase.
I would like to start to delete unnecessary lifetime annotation in struct definition so that it is easier and more clear to reason about the lifetime of data structure without sacrifices the safety and performance.

This PR deletes lifetime annotation in `Guard`.