### PR TITLE
page_store: fix compression / checksum in partial file metadata

### DIFF
--- a/photondb/src/page_store/page_file/file_builder.rs
+++ b/photondb/src/page_store/page_file/file_builder.rs
@@ -219,6 +219,8 @@ impl CommonFileBuilder {
             self.block_size,
             indexes,
             offsets,
+            self.compression,
+            self.checksum,
         ))
     }
 

--- a/photondb/src/page_store/page_file/map_file_reader.rs
+++ b/photondb/src/page_store/page_file/map_file_reader.rs
@@ -56,6 +56,8 @@ impl MapFileMetaHolder {
                 reader.align_size,
                 indexes,
                 offsets,
+                footer.compression,
+                footer.checksum_type,
             );
             let page_table = Self::read_page_table(&reader, &file_meta).await?;
             file_meta_map.insert(page_index.file_id, Arc::new(file_meta));

--- a/photondb/src/page_store/page_file/types.rs
+++ b/photondb/src/page_store/page_file/types.rs
@@ -214,6 +214,8 @@ impl FileMeta {
         block_size: usize,
         meta_indexes: Vec<u64>,
         data_offsets: BTreeMap<u64, u64>,
+        compression: Compression,
+        checksum_type: ChecksumType,
     ) -> Self {
         FileMeta {
             file_id,
@@ -222,8 +224,8 @@ impl FileMeta {
             belong_to: Some(map_file_id),
             meta_indexes,
             data_offsets,
-            compression: Compression::NONE,
-            checksum_type: ChecksumType::CRC32,
+            compression,
+            checksum_type,
         }
     }
 


### PR DESCRIPTION
closes #350

Fix panic when restarting the DB after one map file is generated.

This change:

- Add additional checksum / compression bits to MapFile's footer 
- Generate partial file's FileMeta from MapFile footer

So when read a page from partial file, it will using paritial file' FileMeta(which is consist with MapFile) to read data MapFile.