### PR TITLE
page_store: fix wrong default cache shard count & port est_value_size advisor

### DIFF
--- a/photondb-tools/src/bench/store/photondb.rs
+++ b/photondb-tools/src/bench/store/photondb.rs
@@ -16,6 +16,9 @@ impl Store for PhotondbStore {
     async fn open_table(config: Arc<Args>, env: &Photon) -> Self {
         let mut options = TableOptions::default();
         options.page_store.write_buffer_capacity = 128 << 20;
+        options.page_store.prepopulate_cache_on_flush = false;
+        options.page_store.cache_capacity = 128 << 20;
+        options.page_store.cache_estimated_entry_charge = 2511;
         let table = Table::open(env.to_owned(), &config.db, options)
             .await
             .expect("open table fail");

--- a/photondb-tools/src/bench/util.rs
+++ b/photondb-tools/src/bench/util.rs
@@ -432,7 +432,7 @@ impl<S: Store> Stats<S> {
 	    };
 
         let store_status = cur_store_stats.sub(&ctx.last_store_stats);
-        ctx.last_store_stats = store_status;
+        ctx.last_store_stats = store_status.clone();
 
         let tree_stats = cur_tree_stats.sub(&ctx.last_tree_stats);
         ctx.last_tree_stats = tree_stats.clone();

--- a/photondb/src/lib.rs
+++ b/photondb/src/lib.rs
@@ -72,6 +72,7 @@ mod tests {
             file_base_size: 1 << 20,
             cache_capacity: 2 << 10,
             cache_estimated_entry_charge: 1,
+            cache_file_reader_capacity: 1000,
             prepopulate_cache_on_flush: true,
             separate_hot_cold_files: false,
             compression_on_flush: Compression::SNAPPY,

--- a/photondb/src/page_store/mod.rs
+++ b/photondb/src/page_store/mod.rs
@@ -113,6 +113,11 @@ pub struct Options {
     ///   by not utilizing the full capacity.
     pub cache_estimated_entry_charge: usize,
 
+    /// The capacity of file_reader cache.
+    ///
+    /// Default: 5000 file_readers.
+    pub cache_file_reader_capacity: u64,
+
     /// Insert warm pages into PageCache during flush if true.
     ///
     /// Default: false
@@ -153,6 +158,7 @@ impl Default for Options {
             file_base_size: 8 << 20,
             cache_capacity: 8 << 20,
             cache_estimated_entry_charge: 8 << 10,
+            cache_file_reader_capacity: 5000,
             prepopulate_cache_on_flush: false,
             separate_hot_cold_files: true,
             compression_on_flush: Compression::SNAPPY,

--- a/photondb/src/page_store/page_file/file_reader.rs
+++ b/photondb/src/page_store/page_file/file_reader.rs
@@ -201,7 +201,7 @@ pub(super) struct FileReaderCache<E: Env> {
 
 impl<E: Env> FileReaderCache<E> {
     pub(super) fn new(max_size: u64) -> Self {
-        let cache = Arc::new(ClockCache::new(max_size as usize, 1, -1, false));
+        let cache = Arc::new(ClockCache::new(max_size as usize, 76, -1, false));
         Self {
             cache,
             _marker: PhantomData,

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -29,8 +29,6 @@ pub(crate) mod constant {
 
     pub(crate) const IO_BUFFER_SIZE: usize = 4096 * 4;
 
-    pub(crate) const MAX_OPEN_READER_FD_NUM: u64 = 1000;
-
     pub(crate) const PAGE_FILE_MAGIC: u64 = 142857;
     pub(crate) const MAP_FILE_MAGIC: u64 = 0x179394;
 }
@@ -39,7 +37,7 @@ pub(crate) mod facade {
     use std::{path::PathBuf, sync::Arc};
 
     use super::{
-        constant::{DEFAULT_BLOCK_SIZE, MAX_OPEN_READER_FD_NUM},
+        constant::DEFAULT_BLOCK_SIZE,
         file_reader::{self, CommonFileReader, FileReaderCache, MetaReader},
         types::PageHandle,
         *,
@@ -78,7 +76,7 @@ pub(crate) mod facade {
         ) -> Self {
             let base = base.into();
             let base_dir = env.open_dir(&base).await.expect("open base dir fail");
-            let reader_cache = FileReaderCache::new(MAX_OPEN_READER_FD_NUM);
+            let reader_cache = FileReaderCache::new(options.cache_file_reader_capacity);
             let page_cache = Arc::new(ClockCache::new(
                 options.cache_capacity,
                 options.cache_estimated_entry_charge,

--- a/photondb/src/page_store/stats.rs
+++ b/photondb/src/page_store/stats.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use crate::util::atomic::Counter;
 
 /// Statistics of page store.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct StoreStats {
     /// Statistics of page cache.
     pub page_cache: CacheStats,
@@ -39,18 +39,7 @@ impl Display for StoreStats {
         )?;
         writeln!(
             f,
-            "FileReaderCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}",
-            self.file_reader_cache.lookup_hit,
-            self.file_reader_cache.lookup_miss,
-            (self.file_reader_cache.lookup_hit as f64) * 100.
-                / (self.file_reader_cache.lookup_hit + self.file_reader_cache.lookup_miss) as f64,
-            self.file_reader_cache.insert,
-            self.file_reader_cache.active_evict,
-            self.file_reader_cache.passive_evict,
-        )?;
-        writeln!(
-            f,
-            "PageCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}",
+            "PageCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}, recommand: {:?}",
             self.page_cache.lookup_hit,
             self.page_cache.lookup_miss,
             (self.page_cache.lookup_hit as f64) * 100.
@@ -58,19 +47,33 @@ impl Display for StoreStats {
             self.page_cache.insert,
             self.page_cache.active_evict,
             self.page_cache.passive_evict,
+            self.page_cache.recommendation,
+        )?;
+        writeln!(
+            f,
+            "FileReaderCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}, recommand: {:?}",
+            self.file_reader_cache.lookup_hit,
+            self.file_reader_cache.lookup_miss,
+            (self.file_reader_cache.lookup_hit as f64) * 100.
+                / (self.file_reader_cache.lookup_hit + self.file_reader_cache.lookup_miss) as f64,
+            self.file_reader_cache.insert,
+            self.file_reader_cache.active_evict,
+            self.file_reader_cache.passive_evict,
+            self.file_reader_cache.recommendation,
         )?;
         self.jobs.fmt(f)
     }
 }
 
 /// Statistics of cache.
-#[derive(Default, Clone, Debug, Copy)]
+#[derive(Default, Clone, Debug)]
 pub struct CacheStats {
     pub lookup_hit: u64,
     pub lookup_miss: u64,
     pub insert: u64,
     pub active_evict: u64,
     pub passive_evict: u64,
+    pub recommendation: Vec<String>,
 }
 
 impl CacheStats {
@@ -81,6 +84,7 @@ impl CacheStats {
             insert: self.insert.wrapping_sub(o.insert),
             active_evict: self.active_evict.wrapping_sub(o.active_evict),
             passive_evict: self.passive_evict.wrapping_sub(o.passive_evict),
+            recommendation: self.recommendation.to_owned(),
         }
     }
 
@@ -91,6 +95,7 @@ impl CacheStats {
             insert: self.insert.wrapping_add(o.insert),
             active_evict: self.active_evict.wrapping_add(o.active_evict),
             passive_evict: self.passive_evict.wrapping_add(o.passive_evict),
+            recommendation: [self.recommendation.to_owned(), o.recommendation.to_owned()].concat(),
         }
     }
 }

--- a/photondb/src/page_store/stats.rs
+++ b/photondb/src/page_store/stats.rs
@@ -39,7 +39,7 @@ impl Display for StoreStats {
         )?;
         writeln!(
             f,
-            "PageCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}, recommand: {:?}",
+            "PageCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}, recommendation: {:?}",
             self.page_cache.lookup_hit,
             self.page_cache.lookup_miss,
             (self.page_cache.lookup_hit as f64) * 100.
@@ -51,7 +51,7 @@ impl Display for StoreStats {
         )?;
         writeln!(
             f,
-            "FileReaderCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}, recommand: {:?}",
+            "FileReaderCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evict: {}, passive_evict: {}, recommendation: {:?}",
             self.file_reader_cache.lookup_hit,
             self.file_reader_cache.lookup_miss,
             (self.file_reader_cache.lookup_hit as f64) * 100.


### PR DESCRIPTION
- In desired, Cache will auto-cal the shard count by 32MiB per shard, but the current code is wrong only have one shard
- Port Rocksdb est_value_size advise logic to bench to warn in --db-stats when cache_estimated_entry_charge value is not suitable
- Let `cache_file_reader_capacity` can be configurated in option

run the randomread in the same dataset 2000000 keys with the same seed: 

`bench -t 1 -b readrandom --db /home/robi/testp341914 --num 2000000 --db-stats --key-rand-dist=uniform --seed-base 1669892707258583`

before this pr:(+ change cache_capacity to the same 128MiB)

`PageCacheStats: lookup_hit: 7008096, lookup_miss: 3924009, hit_rate: 64.10564113681674%, insert: 3924009, active_evict: 0, passive_evict: 3896485`

after 

`PageCacheStats: lookup_hit: 7820292, lookup_miss: 3111813, hit_rate: 71.53509776936829%, insert: 3111813, active_evict: 0, passive_evict: 3061744, recommand: []`