### PR TITLE
tools: change bench default env to std

### DIFF
--- a/photondb-tools/src/bench/mod.rs
+++ b/photondb-tools/src/bench/mod.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueEnum};
 
 mod error;
 pub(crate) use error::Result;
-use photondb::env::{Env, Std};
+use photondb::env::Env;
 
 use self::{store::*, workloads::Workloads};
 
@@ -188,8 +188,9 @@ impl fmt::Display for ValueSizeDistributionType {
 }
 
 pub(crate) async fn run(config: Args) -> Result<()> {
+    use photondb::env::Std as BenchEnv;
     match config.store_type {
-        StoreType::Photon => run_store::<PhotondbStore<Std>, Std>(config, Std).await,
+        StoreType::Photon => run_store::<PhotondbStore<BenchEnv>, BenchEnv>(config, BenchEnv).await,
     }
 }
 

--- a/photondb-tools/src/bench/mod.rs
+++ b/photondb-tools/src/bench/mod.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueEnum};
 
 mod error;
 pub(crate) use error::Result;
-use photondb::env::Photon;
+use photondb::env::{Env, Std};
 
 use self::{store::*, workloads::Workloads};
 
@@ -189,12 +189,12 @@ impl fmt::Display for ValueSizeDistributionType {
 
 pub(crate) async fn run(config: Args) -> Result<()> {
     match config.store_type {
-        StoreType::Photon => run_store::<PhotondbStore>(config).await,
+        StoreType::Photon => run_store::<PhotondbStore<Std>, Std>(config, Std).await,
     }
 }
 
-async fn run_store<E: Store>(config: Args) -> Result<()> {
-    let (config, env) = (config.to_owned(), Photon);
-    let mut bench = Workloads::<E>::prepare(config, env).await;
+async fn run_store<S: Store<E>, E: Env>(config: Args, env: E) -> Result<()> {
+    let (config, env) = (config.to_owned(), env);
+    let mut bench = Workloads::<S, E>::prepare(config, env).await;
     bench.execute().await
 }

--- a/photondb-tools/src/bench/store/mod.rs
+++ b/photondb-tools/src/bench/store/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ::photondb::{env::Photon, StoreStats, TreeStats};
+use ::photondb::{StoreStats, TreeStats};
 use async_trait::async_trait;
 
 mod photondb;
@@ -9,8 +9,8 @@ pub(crate) use self::photondb::PhotondbStore;
 use super::*;
 
 #[async_trait]
-pub(crate) trait Store: Clone + Sync + Send + 'static {
-    async fn open_table(config: Arc<Args>, _env: &Photon) -> Self;
+pub(crate) trait Store<E>: Clone + Sync + Send + 'static {
+    async fn open_table(config: Arc<Args>, env: &E) -> Self;
 
     async fn put(&self, key: &[u8], lsn: u64, value: &[u8]) -> Result<()>;
 

--- a/photondb-tools/src/bench/store/photondb.rs
+++ b/photondb-tools/src/bench/store/photondb.rs
@@ -1,19 +1,22 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use photondb::{env::Photon, raw::Table, StoreStats, TableOptions, TreeStats};
+use photondb::{env::Env, raw::Table, StoreStats, TableOptions, TreeStats};
 
 use super::Store;
 use crate::bench::{Args, Result};
 
 #[derive(Clone)]
-pub(crate) struct PhotondbStore {
-    table: Table<Photon>,
+pub(crate) struct PhotondbStore<E: Env + Sync + Send + 'static> {
+    table: Table<E>,
 }
 
 #[async_trait]
-impl Store for PhotondbStore {
-    async fn open_table(config: Arc<Args>, env: &Photon) -> Self {
+impl<E: Env + Sync + Send + 'static> Store<E> for PhotondbStore<E>
+where
+    <E as photondb::env::Env>::JoinHandle<()>: Sync,
+{
+    async fn open_table(config: Arc<Args>, env: &E) -> Self {
         let mut options = TableOptions::default();
         options.page_store.write_buffer_capacity = 128 << 20;
         options.page_store.prepopulate_cache_on_flush = false;


### PR DESCRIPTION
Current Photon Env's `pread` impl is block and sync (in tokio), it's better use sync api as default

With the same data size 2000k and the same seed to random read: (read_in_files: 9998582

| tokio  | uring | std |
| ------------- | ------------- | ------------- |
|  54138.19850250811 ops/sec  | 88755.64525782471 ops/sec  | 131970.66758061736 ops/sec |