### PR TITLE
tree: try split parent after node splitted

### DIFF
--- a/photondb/src/lib.rs
+++ b/photondb/src/lib.rs
@@ -61,8 +61,8 @@ mod tests {
     use crate::page_store::{ChecksumType, Compression};
 
     const OPTIONS: TableOptions = TableOptions {
-        page_size: 64,
-        page_chain_length: 2,
+        page_size: 128,
+        page_chain_length: 4,
         page_store: PageStoreOptions {
             write_buffer_capacity: 1 << 20,
             max_write_buffers: 8,

--- a/photondb/src/tree/mod.rs
+++ b/photondb/src/tree/mod.rs
@@ -585,9 +585,7 @@ impl<'a, E: Env> TreeTxn<'a, E> {
 
         // Try to consolidate the parent page if it is too long.
         if self.should_consolidate_page(parent.page) {
-            let _ = self
-                .consolidate_and_restructure_page(parent.to_owned())
-                .await;
+            let _ = self.consolidate_and_restructure_page(parent).await;
         }
         Ok(())
     }
@@ -868,6 +866,7 @@ impl<'a, 't: 'a, E: Env> TreeIter<'a, 't, E> {
                 let view = self.txn.page_view(index.id, None).await?;
                 if view.page.epoch() == index.epoch {
                     let iter = self.txn.iter_page(&view).await?;
+                    self.inner_next = inner_next;
                     return Ok(Some(PageIter::new(iter, self.options.max_lsn)));
                 } else {
                     // The page epoch has changed, we need to restart from this.

--- a/photondb/src/tree/mod.rs
+++ b/photondb/src/tree/mod.rs
@@ -411,17 +411,9 @@ impl<'a, E: Env> TreeTxn<'a, E> {
             return Err(Error::InvalidArgument);
         }
         match view.page.tier() {
-            PageTier::Leaf => self.split_page_leaf(view).await,
-            PageTier::Inner => self.split_page_inner(view).await,
+            PageTier::Leaf => self.split_page_impl::<Key, Value>(view).await,
+            PageTier::Inner => self.split_page_impl::<&[u8], Index>(view).await,
         }
-    }
-
-    async fn split_page_inner(&self, view: PageView<'_>) -> Result<()> {
-        self.split_page_impl::<&[u8], Index>(view).await
-    }
-
-    async fn split_page_leaf(&self, view: PageView<'_>) -> Result<()> {
-        self.split_page_impl::<Key, Value>(view).await
     }
 
     async fn split_page_impl<K, V>(&self, mut view: PageView<'_>) -> Result<()>


### PR DESCRIPTION
Fix situation that:

```
Root - Node1
```

append write Node1, then full & split node1, split will add delta to root, and consolidate root, but it seems no chance to trigger root to split.

