### PR TITLE
tools: set cache_strict_capacity_limit=true for bench & refine output info

### DIFF
--- a/photondb-tools/src/bench/mod.rs
+++ b/photondb-tools/src/bench/mod.rs
@@ -131,6 +131,14 @@ pub(crate) struct Args {
     /// Does verify checksum.
     #[arg(long, default_value_t = 1)]
     verify_checksum: u8,
+
+    /// Enable compressioin or not.
+    #[arg(long, default_value_t = false)]
+    enable_compression: bool,
+
+    /// Does report error when no enough memory.
+    #[arg(long, default_value_t = false)]
+    cache_strict_capacity_limit: bool,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/photondb/src/lib.rs
+++ b/photondb/src/lib.rs
@@ -47,7 +47,7 @@ mod tree;
 pub use tree::{Options as TableOptions, PageIter, ReadOptions, TreeStats, WriteOptions};
 
 mod page_store;
-pub use page_store::{ChecksumType, Options as PageStoreOptions, StoreStats};
+pub use page_store::{ChecksumType, Compression, Options as PageStoreOptions, StoreStats};
 
 mod page;
 mod util;
@@ -73,6 +73,7 @@ mod tests {
             cache_capacity: 2 << 10,
             cache_estimated_entry_charge: 1,
             cache_file_reader_capacity: 1000,
+            cache_strict_capacity_limit: false,
             prepopulate_cache_on_flush: true,
             separate_hot_cold_files: false,
             compression_on_flush: Compression::SNAPPY,

--- a/photondb/src/page_store/mod.rs
+++ b/photondb/src/page_store/mod.rs
@@ -32,7 +32,7 @@ mod manifest;
 pub(crate) use manifest::Manifest;
 
 mod page_file;
-pub(crate) use page_file::{Compression, FileInfo, MapFileInfo, PageFiles};
+pub(crate) use page_file::{FileInfo, MapFileInfo, PageFiles};
 
 mod recover;
 mod strategy;
@@ -42,7 +42,7 @@ mod cache;
 pub(crate) use cache::{clock::ClockCache, Cache, CacheEntry};
 
 mod stats;
-pub use page_file::ChecksumType;
+pub use page_file::{ChecksumType, Compression};
 pub use stats::StoreStats;
 
 use self::stats::{AtomicJobStats, AtomicWritebufStats};
@@ -119,6 +119,11 @@ pub struct Options {
     /// Default: 5000 file_readers.
     pub cache_file_reader_capacity: u64,
 
+    /// Whelther report error when no enough memory for page cache.
+    ///
+    /// Default: false
+    pub cache_strict_capacity_limit: bool,
+
     /// Insert warm pages into PageCache during flush if true.
     ///
     /// Default: false
@@ -167,6 +172,7 @@ impl Default for Options {
             cache_capacity: 8 << 20,
             cache_estimated_entry_charge: 8 << 10,
             cache_file_reader_capacity: 5000,
+            cache_strict_capacity_limit: false,
             prepopulate_cache_on_flush: false,
             separate_hot_cold_files: true,
             compression_on_flush: Compression::SNAPPY,

--- a/photondb/src/page_store/mod.rs
+++ b/photondb/src/page_store/mod.rs
@@ -119,7 +119,7 @@ pub struct Options {
     /// Default: 5000 file_readers.
     pub cache_file_reader_capacity: u64,
 
-    /// Whelther report error when no enough memory for page cache.
+    /// Whether report error when there is no enough memory for the page cache.
     ///
     /// Default: false
     pub cache_strict_capacity_limit: bool,

--- a/photondb/src/page_store/page_file/compression.rs
+++ b/photondb/src/page_store/page_file/compression.rs
@@ -3,9 +3,13 @@ use bitflags::bitflags;
 use crate::page_store::{Error, Result};
 
 bitflags! {
+    /// Compression method.
     pub struct Compression: u8 {
+        /// Not compression.
         const NONE = 1;
+        /// Compression with Snappy.
         const SNAPPY = 2;
+        /// Compression with ZSTD.
         const ZSTD = 4;
     }
 }

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -16,7 +16,7 @@ mod map_file_reader;
 pub(crate) use map_file_reader::{MapFileMetaHolder, MapFileReader};
 
 mod compression;
-pub(crate) use compression::Compression;
+pub use compression::Compression;
 
 mod checksum;
 pub use checksum::ChecksumType;
@@ -81,7 +81,7 @@ pub(crate) mod facade {
                 options.cache_capacity,
                 options.cache_estimated_entry_charge,
                 -1,
-                false,
+                options.cache_strict_capacity_limit,
                 false,
             ));
             let use_direct = options.use_direct_io;

--- a/photondb/src/page_store/stats.rs
+++ b/photondb/src/page_store/stats.rs
@@ -64,6 +64,7 @@ impl Display for StoreStats {
             self.file_reader_cache.passive_evict,
             self.file_reader_cache.recommendation,
         )?;
+        self.buffer_set.fmt(f)?;
         self.jobs.fmt(f)
     }
 }
@@ -235,8 +236,7 @@ impl Display for BufferSetStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "BufferSet: stall_writes: {}
-                    stall_intervals_ms: {}",
+            "BufferSet: stall_writes: {} stall_intervals_ms: {}",
             self.stall_writes, self.stall_intervals_ms,
         )
     }


### PR DESCRIPTION
1. Set `cache_strict_capacity_limit=true`, so we should see some operation fail with `Error::MemoryLimit` instead of OOM(in desired)
2. Support enable or disable compression with bench arg, default disable
3. Output min/max/avg in bench tools and benchmark.sh result
4. add stall cnt oupt in benchmark.sh result