### PR TITLE
Save page info

### DIFF
--- a/photondb/src/page/mod.rs
+++ b/photondb/src/page/mod.rs
@@ -10,7 +10,7 @@ mod codec;
 
 mod base_page;
 use base_page::PageBuilder;
-pub(crate) use base_page::{PageBuf, PageKind, PageRef, PageTier};
+pub(crate) use base_page::{PageBuf, PageInfo, PageKind, PageRef, PageTier};
 
 mod sorted_page;
 pub(crate) use sorted_page::{

--- a/photondb/src/page_store/jobs/flush.rs
+++ b/photondb/src/page_store/jobs/flush.rs
@@ -206,7 +206,7 @@ impl<E: Env> FlushCtx<E> {
                     }
                     let content = page.data();
                     builder
-                        .add_page(header.page_id(), page_addr, content)
+                        .add_page(header.page_id(), page_addr, page.info(), content)
                         .await?;
                     write_bytes += content.len();
                     let _ = self.page_files.populate_cache(page_addr, content);

--- a/photondb/src/page_store/page_file/map_file_builder.rs
+++ b/photondb/src/page_store/page_file/map_file_builder.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::{
     env::Env,
+    page::PageInfo,
     page_store::{Error, Result},
 };
 
@@ -148,10 +149,17 @@ impl<'a, E: Env> PartialFileBuilder<'a, E> {
         &mut self,
         page_id: u64,
         page_addr: u64,
+        page_info: PageInfo,
         page_content: &[u8],
     ) -> Result<()> {
         self.inner
-            .add_page(&mut self.builder.writer, page_id, page_addr, page_content)
+            .add_page(
+                &mut self.builder.writer,
+                page_id,
+                page_addr,
+                page_info,
+                page_content,
+            )
             .await
     }
 
@@ -364,21 +372,34 @@ mod tests {
 
         // Add page file 1.
         let mut file_builder = builder.add_file(1);
-        file_builder.add_page(1, 1, &[]).await.unwrap();
+        file_builder
+            .add_page(1, 1, empty_page_info(), &[])
+            .await
+            .unwrap();
 
         let builder = file_builder.finish().await.unwrap();
 
         // Add page file 2.
         let mut file_builder = builder.add_file(2);
-        file_builder.add_page(1, 1, &[]).await.unwrap();
+        file_builder
+            .add_page(1, 1, empty_page_info(), &[])
+            .await
+            .unwrap();
 
         let builder = file_builder.finish().await.unwrap();
 
         // Add page file 3.
         let mut file_builder = builder.add_file(3);
-        file_builder.add_page(1, 1, &[]).await.unwrap();
+        file_builder
+            .add_page(1, 1, empty_page_info(), &[])
+            .await
+            .unwrap();
 
         let mut builder = file_builder.finish().await.unwrap();
         builder.finish(1).await.unwrap();
+    }
+
+    fn empty_page_info() -> PageInfo {
+        PageInfo::from_raw(0, 0, 0)
     }
 }

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -404,6 +404,7 @@ pub(crate) mod facade {
         use tempdir::TempDir;
 
         use super::*;
+        use crate::page::PageInfo;
 
         #[photonio::test]
         fn test_file_builder() {
@@ -415,7 +416,10 @@ pub(crate) mod facade {
                 .await
                 .unwrap();
             builder.add_delete_pages(&[1, 2]);
-            builder.add_page(3, 1, &[3, 4, 1]).await.unwrap();
+            builder
+                .add_page(3, 1, empty_page_info(), &[3, 4, 1])
+                .await
+                .unwrap();
             builder.finish().await.unwrap();
         }
 
@@ -433,13 +437,13 @@ pub(crate) mod facade {
                     .await
                     .unwrap();
                 b.add_delete_pages(&[page_addr(1, 0), page_addr(1, 1)]);
-                b.add_page(1, page_addr(2, 2), &[7].repeat(8192))
+                b.add_page(1, page_addr(2, 2), empty_page_info(), &[7].repeat(8192))
                     .await
                     .unwrap();
-                b.add_page(2, page_addr(2, 3), &[8].repeat(8192 / 2))
+                b.add_page(2, page_addr(2, 3), empty_page_info(), &[8].repeat(8192 / 2))
                     .await
                     .unwrap();
-                b.add_page(3, page_addr(2, 4), &[9].repeat(8192 / 3))
+                b.add_page(3, page_addr(2, 4), empty_page_info(), &[9].repeat(8192 / 3))
                     .await
                     .unwrap();
                 let info = b.finish().await.unwrap();
@@ -488,13 +492,13 @@ pub(crate) mod facade {
                     .await
                     .unwrap();
                 b.add_delete_pages(&[page_addr(1, 0), page_addr(1, 1)]);
-                b.add_page(1, page_addr(2, 2), &[7].repeat(8192))
+                b.add_page(1, page_addr(2, 2), empty_page_info(), &[7].repeat(8192))
                     .await
                     .unwrap();
-                b.add_page(2, page_addr(2, 3), &[8].repeat(8192 / 2))
+                b.add_page(2, page_addr(2, 3), empty_page_info(), &[8].repeat(8192 / 2))
                     .await
                     .unwrap();
-                b.add_page(3, page_addr(2, 4), &[9].repeat(8192 / 3))
+                b.add_page(3, page_addr(2, 4), empty_page_info(), &[9].repeat(8192 / 3))
                     .await
                     .unwrap();
                 b.finish().await.unwrap()
@@ -550,9 +554,15 @@ pub(crate) mod facade {
                     .new_page_file_builder(file_id, Compression::ZSTD)
                     .await
                     .unwrap();
-                b.add_page(1, page_addr1, &[1].repeat(10)).await.unwrap();
-                b.add_page(1, page_addr2, &[2].repeat(10)).await.unwrap();
-                b.add_page(2, page_addr3, &[3].repeat(10)).await.unwrap();
+                b.add_page(1, page_addr1, empty_page_info(), &[1].repeat(10))
+                    .await
+                    .unwrap();
+                b.add_page(1, page_addr2, empty_page_info(), &[2].repeat(10))
+                    .await
+                    .unwrap();
+                b.add_page(2, page_addr3, empty_page_info(), &[3].repeat(10))
+                    .await
+                    .unwrap();
                 let file_info = b.finish().await.unwrap();
                 assert!(file_info.get_page_handle(page_addr1).is_some())
             }
@@ -581,8 +591,12 @@ pub(crate) mod facade {
                     .new_page_file_builder(file_id, Compression::ZSTD)
                     .await
                     .unwrap();
-                b.add_page(1, page_addr1, &[1].repeat(10)).await.unwrap();
-                b.add_page(1, page_addr2, &[2].repeat(10)).await.unwrap();
+                b.add_page(1, page_addr1, empty_page_info(), &[1].repeat(10))
+                    .await
+                    .unwrap();
+                b.add_page(1, page_addr2, empty_page_info(), &[2].repeat(10))
+                    .await
+                    .unwrap();
                 let file_info = b.finish().await.unwrap();
                 assert!(file_info.get_page_handle(page_addr1).is_some())
             }
@@ -623,6 +637,10 @@ pub(crate) mod facade {
                 cache_capacity: 2 << 10,
                 ..Default::default()
             }
+        }
+
+        fn empty_page_info() -> PageInfo {
+            PageInfo::from_raw(0, 0, 0)
         }
     }
 }

--- a/photondb/src/tree/page.rs
+++ b/photondb/src/tree/page.rs
@@ -11,7 +11,7 @@ pub(super) const NULL_INDEX: Index = Index::new(NAN_ID, 0);
 pub(super) struct PageView<'a> {
     pub(super) id: u64,
     pub(super) addr: u64,
-    pub(super) page: PageRef<'a>,
+    pub(super) page: PageInfo,
     pub(super) range: Option<Range<'a>>,
 }
 


### PR DESCRIPTION
This PR saves the page info into page/map files, to speed up `find_leaf`.

The `PageInfo` consists of three parts: 
1. page meta (flags, chain length, epoch)
2. page chain next
3. page size

The chain next and page size are required by `TreeTxn::should_split_page`, which is used in `TreeTxn` to avoid to avoid starving the split operation due to contentions.