### PR TITLE
page_store: map file support dealloc pages

### DIFF
--- a/photondb/src/page_store/manifest.rs
+++ b/photondb/src/page_store/manifest.rs
@@ -17,6 +17,8 @@ pub(crate) struct Manifest<E: Env> {
 
     max_file_size: u64,
 
+    next_map_file_id: u32,
+
     current_file_num: Option<u32>,
     current_writer: Option<ManifestWriter<E::SequentialWriter>>,
 }
@@ -37,6 +39,7 @@ impl<E: Env> Manifest<E> {
             base,
             base_dir: None,
             max_file_size: MAX_MANIFEST_SIZE,
+            next_map_file_id: 0,
             current_file_num: Default::default(),
             current_writer: None,
         };
@@ -75,6 +78,16 @@ impl<E: Env> Manifest<E> {
             .expect("open base dir fail");
         self.base_dir = Some(base_dir);
         Ok(())
+    }
+
+    pub(super) fn reset_next_map_file_id(&mut self, next_id: u32) {
+        self.next_map_file_id = next_id;
+    }
+
+    pub(crate) fn next_map_file_id(&mut self) -> u32 {
+        let id = self.next_map_file_id;
+        self.next_map_file_id += 1;
+        id
     }
 
     // Record a new version_edit to manifest file.

--- a/photondb/src/page_store/page_file/file_builder.rs
+++ b/photondb/src/page_store/page_file/file_builder.rs
@@ -34,6 +34,8 @@ use crate::{
 ///
 /// `page_addr`'s high 32 bit always be `file-id`(`PageAddr = {file id} {write
 /// buffer index}`), so it only store lower 32 bit.
+
+#[allow(unused)]
 pub(crate) struct FileBuilder<'a, E: Env> {
     writer: BufferedWriter<'a, E>,
     inner: CommonFileBuilder,
@@ -58,6 +60,8 @@ impl<'a, E: Env> FileBuilder<'a, E> {
     }
 
     /// Add a new page to builder.
+
+    #[allow(unused)]
     pub(crate) async fn add_page(
         &mut self,
         page_id: u64,
@@ -77,11 +81,13 @@ impl<'a, E: Env> FileBuilder<'a, E> {
     }
 
     /// Add delete page to builder.
+    #[allow(unused)]
     pub(crate) fn add_delete_pages(&mut self, page_addrs: &[u64]) {
         self.inner.add_delete_pages(page_addrs)
     }
 
     // Finish build page file.
+    #[allow(unused)]
     pub(crate) async fn finish(&mut self) -> Result<FileInfo> {
         self.inner.finish_meta_block(&mut self.writer).await?;
         let info = self.finish_file_footer().await?;
@@ -235,6 +241,7 @@ impl CommonFileBuilder {
         ))
     }
 
+    #[allow(unused)]
     pub(super) fn as_page_file_meta(
         &self,
         file_size: usize,
@@ -287,6 +294,7 @@ impl BlockHandler {
     }
 }
 
+#[allow(unused)]
 pub(crate) struct Footer {
     magic: u64,
     pub(crate) data_handle: BlockHandler,
@@ -301,6 +309,7 @@ impl Footer {
         (core::mem::size_of::<u64>() * 5 + 1 + 1) as u32
     }
 
+    #[allow(unused)]
     fn encode(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(core::mem::size_of::<u64>() * 5);
         bytes.extend_from_slice(&self.magic.to_le_bytes());
@@ -350,6 +359,7 @@ impl MetaBlockBuilder {
         self.page_table.0.insert(page_addr, page_id);
     }
 
+    #[allow(unused)]
     pub(crate) fn delete_pages(&mut self, page_addrs: &[u64]) {
         for page_addr in page_addrs {
             self.delete_page_addrs.0.insert(*page_addr);

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod constant {
 
     pub(crate) const IO_BUFFER_SIZE: usize = 4096 * 4;
 
+    #[allow(unused)]
     pub(crate) const PAGE_FILE_MAGIC: u64 = 142857;
     pub(crate) const MAP_FILE_MAGIC: u64 = 0x179394;
 }
@@ -96,6 +97,7 @@ pub(crate) mod facade {
         }
 
         /// Create `FileBuilder` to write a new page file.
+        #[allow(unused)]
         pub(crate) async fn new_page_file_builder(
             &self,
             file_id: u32,

--- a/photondb/src/page_store/page_file/types.rs
+++ b/photondb/src/page_store/page_file/types.rs
@@ -418,12 +418,29 @@ pub(crate) struct MapFileInfo {
     up1: u32,
     up2: u32,
 
+    /// The referenced page files, this should be placed in meta.
+    referenced_files: HashSet<u32>,
+
     meta: Arc<MapFileMeta>,
 }
 
 impl MapFileInfo {
-    pub(crate) fn new(up1: u32, up2: u32, meta: Arc<MapFileMeta>) -> Self {
-        MapFileInfo { up1, up2, meta }
+    pub(crate) fn new(
+        up1: u32,
+        up2: u32,
+        referenced_files: HashSet<u32>,
+        meta: Arc<MapFileMeta>,
+    ) -> Self {
+        MapFileInfo {
+            up1,
+            up2,
+            referenced_files,
+            meta,
+        }
+    }
+
+    pub(crate) fn get_referenced_files(&self) -> &HashSet<u32> {
+        &self.referenced_files
     }
 
     pub(crate) fn on_update(&mut self, now: u32) {

--- a/photondb/src/page_store/page_txn.rs
+++ b/photondb/src/page_store/page_txn.rs
@@ -558,7 +558,6 @@ mod tests {
 
     #[photonio::test]
     async fn page_txn_insert_page() {
-        env_logger::init();
         let env = crate::env::Photon;
         let base = tempdir::TempDir::new("test_page_insert_page").unwrap();
         let files = Arc::new(PageFiles::new(env, base.path(), &test_option()).await);


### PR DESCRIPTION
... and use map file as the output format, the staled codes related to page files will be removed later.

Close #387, close #390.