### PR TITLE
page_store,tools: using fnv hash & disable prepopulate as default

### DIFF
--- a/photondb-tools/src/bench/store/photondb.rs
+++ b/photondb-tools/src/bench/store/photondb.rs
@@ -23,7 +23,7 @@ where
             std::fs::remove_dir_all(&config.db).unwrap();
         }
         let mut options = TableOptions::default();
-        options.page_store.prepopulate_cache_on_flush = true;
+        options.page_store.prepopulate_cache_on_flush = false;
         options.page_store.cache_strict_capacity_limit = true;
         options.page_store.cache_estimated_entry_charge = 4840;
         options.page_store.cache_capacity = config.cache_size as usize;

--- a/photondb/src/page_store/cache/clock.rs
+++ b/photondb/src/page_store/cache/clock.rs
@@ -1021,8 +1021,22 @@ impl<T: Clone> ClockCache<T> {
 
     #[inline]
     fn hash_key(key: u64) -> u32 {
-        // Fibonacci hash https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
-        const FIBONACCI_MAGIC_NUMBER_64BIT: u64 = 11400714819323198485;
-        (key.wrapping_mul(FIBONACCI_MAGIC_NUMBER_64BIT) >> 32) as u32 // TODO: cmp with hash for seprated file_id, offset and other algorithm(siphash, fnv, xxhash?).
+        // fnv32: https://github.com/golang/go/blob/master/src/hash/fnv/fnv.go#L99
+        const OFFSET32: u32 = 2166136261;
+        const PRIME32: u32 = 16777619;
+
+        let (mut file_id, mut offset) = ((key >> 32) as u32, key as u32);
+        let mut h = OFFSET32;
+        for _ in 0..4 {
+            h = h.wrapping_mul(PRIME32);
+            h ^= (file_id & 0xff) as u32;
+            file_id >>= 8;
+        }
+        for _ in 0..4 {
+            h = h.wrapping_mul(PRIME32);
+            h ^= (offset & 0xff) as u32;
+            offset >>= 8;
+        }
+        h
     }
 }

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod constant {
     // like: https://github.com/DataDog/glommio/issues/7 or https://github.com/facebook/rocksdb/pull/1875
     pub(crate) const DEFAULT_BLOCK_SIZE: usize = 4096;
 
-    pub(crate) const IO_BUFFER_SIZE: usize = 4096 * 4;
+    pub(crate) const IO_BUFFER_SIZE: usize = 8 << 20;
 
     #[allow(unused)]
     pub(crate) const PAGE_FILE_MAGIC: u64 = 142857;


### PR DESCRIPTION
-  change hash fn to fnv and cal with file_id + offset to reduce collision on bucket(find_pointer still have high cost in fillrandom flamegraph
-  disable prepopulate_cache_on_flush again, prepopulate_cache_on_flush seen help cache hit rate, but let flush slower, at last it make lower thoughput
- enlarge IO_BUFF