### PR TITLE
page_store: move evict cache from flush to cleanup file phase

### DIFF
--- a/photondb/src/page_store/cache/clock.rs
+++ b/photondb/src/page_store/cache/clock.rs
@@ -1001,6 +1001,10 @@ impl<T: Clone> Cache<T> for ClockCache<T> {
         shard.erase(key, hash)
     }
 
+    fn erase_file_pages(self: &std::sync::Arc<Self>, _file_id: u32) {
+        unimplemented!()
+    }
+
     fn stats(self: &Arc<Self>) -> CacheStats {
         let mut summary = CacheStats::default();
         for s in &self.shards {

--- a/photondb/src/page_store/jobs/cleanup.rs
+++ b/photondb/src/page_store/jobs/cleanup.rs
@@ -59,6 +59,7 @@ impl<E: Env> CleanupCtx<E> {
 
         if !obsoleted_files.is_empty() {
             info!("Clean obsoleted files {obsoleted_files:?}");
+            self.page_files.evict_cached_pages(&obsoleted_files);
             self.page_files.remove_files(obsoleted_files).await;
         }
     }

--- a/photondb/src/page_store/jobs/flush.rs
+++ b/photondb/src/page_store/jobs/flush.rs
@@ -191,8 +191,6 @@ impl<E: Env> FlushCtx<E> {
         let group_id = write_buffer.group_id();
         info!("Flush write buffer {group_id} to file, {flush_stats}");
 
-        self.page_files.evict_cached_pages(&dealloc_pages);
-
         let file_id = {
             let mut lock = self.manifest.lock().await;
             lock.next_file_id()

--- a/photondb/src/page_store/page_file/mod.rs
+++ b/photondb/src/page_store/page_file/mod.rs
@@ -276,9 +276,9 @@ pub(crate) mod facade {
             Ok(())
         }
 
-        pub(crate) fn evict_cached_pages(&self, page_addrs: &[u64]) {
-            for page_addr in page_addrs {
-                self.page_cache.erase(*page_addr);
+        pub(crate) fn evict_cached_pages(&self, files: &[u32]) {
+            for file_id in files {
+                self.page_cache.erase_file_pages(*file_id);
             }
         }
 


### PR DESCRIPTION
Pages may accessible after flush "as dealloc page", so this PR move active evict_page to cleanup file phase