### PR TITLE
page_store: support priority in lru_cache

### DIFF
--- a/photondb/src/page_store/cache/clock.rs
+++ b/photondb/src/page_store/cache/clock.rs
@@ -5,7 +5,7 @@ use ::std::{
 };
 
 use super::*;
-use crate::page_store::stats::CacheStats;
+use crate::page_store::{stats::CacheStats, CacheOption};
 
 const LOAD_FACTOR: f64 = 0.7;
 const STRICT_LOAD_FACTOR: f64 = 0.84;

--- a/photondb/src/page_store/cache/lru.rs
+++ b/photondb/src/page_store/cache/lru.rs
@@ -136,7 +136,7 @@ impl<T: Clone> Cache<T> for LRUCache<T> {
             } else {
                 let token = if unsafe { (*ptr).detached } {
                     CacheToken::new(CACHE_DISCARD)
-                } else if option == CacheOption::REFILL_COLD_WHEN_NOT_FULL {
+                } else if option.refill_cold_when_not_full() {
                     CacheToken::new(CACHE_AS_COLD)
                 } else {
                     CacheToken::default()
@@ -375,7 +375,7 @@ impl<T: Clone> LRUCacheShard<T> {
     }
 
     unsafe fn evict_lru(&mut self, charge: usize, option: CacheOption) -> bool {
-        if option == CacheOption::REFILL_COLD_WHEN_NOT_FULL
+        if option.refill_cold_when_not_full()
             && self.usage.load(Ordering::Relaxed) + charge > self.capacity
         {
             return false;

--- a/photondb/src/page_store/cache/lru.rs
+++ b/photondb/src/page_store/cache/lru.rs
@@ -11,10 +11,12 @@ use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 
 use super::{
-    AtomicCacheStats, Cache, CacheEntry, CacheToken, Handle, Key, LRUHandle, CACHE_AS_COLD,
+    AtomicCacheStats, Cache, CacheEntry, CacheToken, Handle, Key, LRUHandle, CACHE_AS_OLD,
     CACHE_DISCARD,
 };
-use crate::page_store::{cache::CACHE_AS_HOT, stats::CacheStats, CacheOption, Result};
+use crate::page_store::{
+    cache::CACHE_AS_RECENT, page_txn::CachePriority, stats::CacheStats, CacheOption, Result,
+};
 
 pub(crate) struct LRUCache<T: Clone> {
     shards: Vec<Mutex<LRUCacheShard<T>>>,
@@ -23,11 +25,23 @@ pub(crate) struct LRUCache<T: Clone> {
 }
 
 struct LRUCacheShard<T: Clone> {
-    head: Box<LRUHandlePtr<T>>,
     table: LRUCacheHandleTable<T>,
     capacity: usize,
 
     lru_usage: Arc<AtomicUsize>,
+
+    high_pri_ratio: f64,
+    lru_high_pri: Box<LRUHandlePtr<T>>,
+    lru_high_usage: Arc<AtomicUsize>,
+    lru_high_capacity: usize,
+
+    low_pri_ratio: f64,
+    lru_low_pri: Box<LRUHandlePtr<T>>,
+    lru_low_usage: Arc<AtomicUsize>,
+    lru_low_capacity: usize,
+
+    lru_bottom_pri: Box<LRUHandlePtr<T>>,
+
     usage: Arc<AtomicUsize>,
 
     stats: Arc<AtomicCacheStats>,
@@ -54,7 +68,13 @@ unsafe impl<T: Clone> Send for LRUHandlePtr<T> {}
 unsafe impl<T: Clone> Sync for LRUHandlePtr<T> {}
 
 impl<T: Clone> LRUCache<T> {
-    pub(crate) fn new(capacity: usize, num_shard_bits: i32) -> Self {
+    pub(crate) fn new(
+        capacity: usize,
+        num_shard_bits: i32,
+        high_pri_ratio: f64,
+        low_pri_ratio: f64,
+    ) -> Self {
+        assert!(high_pri_ratio + low_pri_ratio < 1.0);
         assert!(num_shard_bits < 20);
         let num_shard_bits = if num_shard_bits >= 0 {
             num_shard_bits as u32
@@ -80,7 +100,7 @@ impl<T: Clone> LRUCache<T> {
         let mut shards = Vec::with_capacity(num_shards as usize);
         let mut stats = Vec::with_capacity(num_shards as usize);
         for _ in 0..num_shards {
-            let shard = LRUCacheShard::new(per_shard_cap);
+            let shard = LRUCacheShard::new(per_shard_cap, high_pri_ratio, low_pri_ratio);
             stats.push(shard.stats.clone());
             shards.push(Mutex::new(shard));
         }
@@ -134,10 +154,10 @@ impl<T: Clone> Cache<T> for LRUCache<T> {
             if ptr.is_null() {
                 None
             } else {
-                let token = if unsafe { (*ptr).detached } {
+                let token = if unsafe { (*ptr).is_detached() } {
                     CacheToken::new(CACHE_DISCARD)
                 } else if option.refill_cold_when_not_full() {
-                    CacheToken::new(CACHE_AS_COLD)
+                    CacheToken::new(CACHE_AS_OLD)
                 } else {
                     CacheToken::default()
                 };
@@ -212,17 +232,26 @@ impl<T: Clone> Cache<T> for LRUCache<T> {
 }
 
 impl<T: Clone> LRUCacheShard<T> {
-    pub(crate) fn new(capacity: usize) -> Self {
-        let mut linked = Box::new(LRUHandle::default());
-        linked.page_link.next = linked.as_mut();
-        linked.page_link.prev = linked.as_mut();
-        let ptr = Box::into_raw(linked);
-        let head = Box::new(LRUHandlePtr { ptr });
+    pub(crate) fn new(capacity: usize, high_pri_ratio: f64, low_pri_ratio: f64) -> Self {
+        let mut dummy = Box::new(LRUHandle::default());
+        dummy.page_link.next = dummy.as_mut();
+        dummy.page_link.prev = dummy.as_mut();
+        let ptr = Box::into_raw(dummy);
+        let lru_high_capacity = ((capacity as f64) * high_pri_ratio) as usize;
+        let lru_low_capacity = ((capacity as f64) * low_pri_ratio) as usize;
         Self {
-            head,
             table: LRUCacheHandleTable::new(),
             capacity,
             lru_usage: Default::default(),
+            lru_high_pri: Box::new(LRUHandlePtr { ptr }),
+            lru_high_usage: Default::default(),
+            lru_high_capacity,
+            high_pri_ratio,
+            lru_low_pri: Box::new(LRUHandlePtr { ptr }),
+            lru_low_usage: Default::default(),
+            lru_low_capacity,
+            low_pri_ratio,
+            lru_bottom_pri: Box::new(LRUHandlePtr { ptr }),
             usage: Default::default(),
             stats: Default::default(),
         }
@@ -242,9 +271,9 @@ impl<T: Clone> LRUCacheShard<T> {
                 hash,
                 value,
                 charge,
-                detached: true,
                 ..Default::default()
             });
+            h.set_detached(true);
             h.file_link.next = h.as_mut();
             h.file_link.prev = h.as_mut();
             let handle = Box::into_raw(h);
@@ -255,9 +284,9 @@ impl<T: Clone> LRUCacheShard<T> {
             value,
             hash,
             charge,
-            detached: false,
             ..Default::default()
         });
+        h.set_priority(option.priority());
         h.file_link.next = h.as_mut();
         h.file_link.prev = h.as_mut();
         let lhd = Box::into_raw(h);
@@ -273,7 +302,7 @@ impl<T: Clone> LRUCacheShard<T> {
 
     unsafe fn release(&mut self, h: *mut LRUHandle<T>, token: CacheToken) {
         assert!(!h.is_null());
-        if (*h).detached {
+        if (*h).is_detached() {
             drop(Box::from_raw(h));
             return;
         }
@@ -291,8 +320,8 @@ impl<T: Clone> LRUCacheShard<T> {
             if self.usage.load(Ordering::Relaxed) <= self.capacity
                 && !token.returning_behavior_match(CACHE_DISCARD)
             {
-                let as_hot = token.returning_behavior_match(CACHE_AS_HOT);
-                self.link_lru(self.head.mut_ptr(), h, as_hot);
+                let as_recent = token.returning_behavior_match(CACHE_AS_RECENT);
+                self.link_lru(h, as_recent);
                 self.link_file(h);
                 return;
             }
@@ -351,27 +380,146 @@ impl<T: Clone> LRUCacheShard<T> {
         }
     }
 
-    unsafe fn link_lru(&mut self, head: *mut LRUHandle<T>, e: *mut LRUHandle<T>, as_recent: bool) {
+    unsafe fn link_lru(&mut self, e: *mut LRUHandle<T>, as_recent: bool) {
         assert!(!e.is_null());
-        if as_recent {
-            (*e).page_link.next = head;
-            (*e).page_link.prev = (*head).page_link.prev;
+        assert!((*e).page_link.next.is_null());
+        assert!((*e).page_link.prev.is_null());
+
+        let pri = (*e).priority();
+        if self.high_pri_ratio > 0.0 && matches!(pri, CachePriority::High) {
+            if as_recent {
+                let lru = self.lru_high_pri.mut_ptr();
+                (*e).page_link.next = lru;
+                (*e).page_link.prev = (*lru).page_link.prev;
+            } else {
+                let lru = self.lru_low_pri.mut_ptr();
+                (*e).page_link.prev = lru;
+                (*e).page_link.next = (*lru).page_link.next;
+            }
+            (*(*e).page_link.prev).page_link.next = e;
+            (*(*e).page_link.next).page_link.prev = e;
+            (*e).set_in_cache_priority(CachePriority::High);
+            self.lru_high_usage
+                .fetch_add((*e).charge, Ordering::Relaxed);
+            self.maintain_priority_size();
+        } else if self.low_pri_ratio > 0.0
+            && matches!(pri, CachePriority::High | CachePriority::Low)
+        {
+            if as_recent {
+                let lru = self.lru_low_pri.mut_ptr();
+                (*e).page_link.next = (*lru).page_link.next;
+                (*e).page_link.prev = lru;
+            } else {
+                let lru = self.lru_bottom_pri.mut_ptr();
+                (*e).page_link.prev = lru;
+                (*e).page_link.next = (*lru).page_link.next;
+            }
+            (*(*e).page_link.prev).page_link.next = e;
+            (*(*e).page_link.next).page_link.prev = e;
+            (*e).set_in_cache_priority(CachePriority::Low);
+            self.lru_low_usage.fetch_add((*e).charge, Ordering::Relaxed);
+            self.maintain_priority_size();
+            if as_recent || std::ptr::eq(self.lru_bottom_pri.mut_ptr(), self.lru_low_pri.mut_ptr())
+            {
+                self.lru_low_pri = Box::new(LRUHandlePtr { ptr: e });
+            }
         } else {
-            (*e).page_link.prev = head;
-            (*e).page_link.next = (*head).page_link.next;
+            if as_recent {
+                let lru = self.lru_bottom_pri.mut_ptr();
+                (*e).page_link.next = (*lru).page_link.next;
+                (*e).page_link.prev = lru;
+            } else {
+                let lru = self.lru_high_pri.mut_ptr();
+                (*e).page_link.prev = lru;
+                (*e).page_link.next = (*lru).page_link.next;
+            }
+            (*(*e).page_link.prev).page_link.next = e;
+            (*(*e).page_link.next).page_link.prev = e;
+            (*e).set_in_cache_priority(CachePriority::Bottom);
+            if as_recent || std::ptr::eq(self.lru_high_pri.mut_ptr(), self.lru_bottom_pri.mut_ptr())
+            {
+                if std::ptr::eq(self.lru_bottom_pri.mut_ptr(), self.lru_low_pri.mut_ptr()) {
+                    self.lru_low_pri = Box::new(LRUHandlePtr { ptr: e });
+                }
+                self.lru_bottom_pri = Box::new(LRUHandlePtr { ptr: e });
+            }
         }
-        (*(*e).page_link.prev).page_link.next = e;
-        (*(*e).page_link.next).page_link.prev = e;
         self.lru_usage.fetch_add((*e).charge, Ordering::Relaxed);
+    }
+
+    unsafe fn maintain_priority_size(&mut self) {
+        // demote high -> low.
+        while self.lru_high_usage.load(Ordering::Relaxed) > self.lru_high_capacity {
+            self.lru_low_pri = Box::new(LRUHandlePtr {
+                ptr: (*self.lru_low_pri.mut_ptr()).page_link.next,
+            });
+            assert!(!std::ptr::eq(
+                self.lru_low_pri.mut_ptr(),
+                self.lru_high_pri.mut_ptr()
+            ));
+            (*self.lru_low_pri.mut_ptr()).set_in_cache_priority(CachePriority::Low);
+            assert!(
+                self.lru_high_usage.load(Ordering::Relaxed) >= (*self.lru_low_pri.mut_ptr()).charge
+            );
+            let charge = (*self.lru_low_pri.mut_ptr()).charge;
+            self.lru_high_usage.fetch_sub(charge, Ordering::Relaxed);
+            self.lru_low_usage.fetch_add(charge, Ordering::Relaxed);
+        }
+
+        // demote low -> bottom.
+        while self.lru_low_usage.load(Ordering::Relaxed) > self.lru_low_capacity {
+            self.lru_bottom_pri = Box::new(LRUHandlePtr {
+                ptr: (*self.lru_bottom_pri.mut_ptr()).page_link.next,
+            });
+            assert!(!std::ptr::eq(
+                self.lru_bottom_pri.mut_ptr(),
+                self.lru_high_pri.mut_ptr()
+            ));
+            (*self.lru_bottom_pri.mut_ptr()).set_in_cache_priority(CachePriority::Bottom);
+            assert!(
+                self.lru_low_usage.load(Ordering::Relaxed)
+                    >= (*self.lru_bottom_pri.mut_ptr()).charge
+            );
+            self.lru_low_usage
+                .fetch_sub((*self.lru_bottom_pri.mut_ptr()).charge, Ordering::Relaxed);
+        }
     }
 
     unsafe fn unlink_lru(&mut self, e: *mut LRUHandle<T>) {
         assert!(!e.is_null());
+        assert!(!(*e).page_link.next.is_null());
+        assert!(!(*e).page_link.prev.is_null());
+
+        if std::ptr::eq(self.lru_low_pri.mut_ptr(), e) {
+            self.lru_low_pri = Box::new(LRUHandlePtr {
+                ptr: (*e).page_link.prev,
+            })
+        }
+
+        if std::ptr::eq(self.lru_bottom_pri.mut_ptr(), e) {
+            self.lru_bottom_pri = Box::new(LRUHandlePtr {
+                ptr: (*e).page_link.prev,
+            })
+        }
+
         (*(*e).page_link.next).page_link.prev = (*e).page_link.prev;
         (*(*e).page_link.prev).page_link.next = (*e).page_link.next;
         (*e).page_link.prev = ptr::null_mut();
         (*e).page_link.next = ptr::null_mut();
+        assert!(self.lru_usage.load(Ordering::Relaxed) >= (*e).charge);
         self.lru_usage.fetch_sub((*e).charge, Ordering::Relaxed);
+        match (*e).in_cache_priority() {
+            CachePriority::High => {
+                assert!(self.lru_high_usage.load(Ordering::Relaxed) >= (*e).charge);
+                self.lru_high_usage
+                    .fetch_sub((*e).charge, Ordering::Relaxed);
+            }
+            CachePriority::Low => {
+                assert!(self.lru_low_usage.load(Ordering::Relaxed) >= (*e).charge);
+                self.lru_low_usage.fetch_sub((*e).charge, Ordering::Relaxed);
+            }
+            CachePriority::Bottom => {}
+        }
     }
 
     unsafe fn evict_lru(&mut self, charge: usize, option: CacheOption) -> bool {
@@ -381,9 +529,12 @@ impl<T: Clone> LRUCacheShard<T> {
             return false;
         }
         while self.usage.load(Ordering::Relaxed) + charge > self.capacity
-            && !std::ptr::eq((*self.head.ptr).page_link.next, self.head.ptr)
+            && !std::ptr::eq(
+                (*self.lru_high_pri.ptr).page_link.next,
+                self.lru_high_pri.ptr,
+            )
         {
-            let old_ptr = (*self.head.ptr).page_link.next;
+            let old_ptr = (*self.lru_high_pri.ptr).page_link.next;
             self.table.remove((*old_ptr).key);
             self.unlink_lru(old_ptr);
             self.unlink_file(old_ptr);

--- a/photondb/src/page_store/page_file/cache.rs
+++ b/photondb/src/page_store/page_file/cache.rs
@@ -15,7 +15,7 @@ pub(super) struct FileReaderCache<E: Env> {
 
 impl<E: Env> FileReaderCache<E> {
     pub(super) fn new(max_size: u64) -> Self {
-        let cache = Arc::new(LRUCache::new(max_size as usize, -1));
+        let cache = Arc::new(LRUCache::new(max_size as usize, -1, 0.0, 0.0));
         Self {
             cache,
             _marker: PhantomData,

--- a/photondb/src/page_store/page_txn.rs
+++ b/photondb/src/page_store/page_txn.rs
@@ -19,7 +19,7 @@ use crate::{
 
 bitflags! {
 /// Cache Option.
-pub struct CacheOption: u32 {
+pub struct CacheOption: u8 {
     /// Default: read from cache first, read disk and refill cache as recent used when cache miss.
     const DEFAULT = 0b00000000;
     /// RefillColdWhenNotFull: read from cache first and read disk when cache miss.

--- a/photondb/src/page_store/page_txn.rs
+++ b/photondb/src/page_store/page_txn.rs
@@ -27,9 +27,9 @@ pub struct CacheOption: u32 {
     /// It's normally be used when read some cold data(not in cache) and discard them soon(i.g. consolidate)
     const REFILL_COLD_WHEN_NOT_FULL = 0b00000001;
 
-    const HIGH_PRI = 0b00000010;
+    const LOW_PRI = 0b00000010;
 
-    const LOW_PRI = 0b00000100;
+    const BOTTOM_PRI = 0b00000100;
 }
 }
 
@@ -41,27 +41,27 @@ impl Default for CacheOption {
 
 impl CacheOption {
     pub(crate) fn priority(&self) -> CachePriority {
-        if self.contains(CacheOption::HIGH_PRI) {
-            CachePriority::High
-        } else if self.contains(CacheOption::LOW_PRI) {
+        if self.contains(CacheOption::LOW_PRI) {
             CachePriority::Low
-        } else {
+        } else if self.contains(CacheOption::BOTTOM_PRI) {
             CachePriority::Bottom
+        } else {
+            CachePriority::High
         }
     }
 
     pub(crate) fn set_priority(mut self, pri: CachePriority) -> Self {
         match pri {
             CachePriority::High => {
-                self.set(CacheOption::HIGH_PRI, true);
+                self.set(CacheOption::BOTTOM_PRI, false);
                 self.set(CacheOption::LOW_PRI, false);
             }
             CachePriority::Low => {
-                self.set(CacheOption::HIGH_PRI, false);
+                self.set(CacheOption::BOTTOM_PRI, false);
                 self.set(CacheOption::LOW_PRI, true);
             }
             CachePriority::Bottom => {
-                self.set(CacheOption::HIGH_PRI, false);
+                self.set(CacheOption::BOTTOM_PRI, true);
                 self.set(CacheOption::LOW_PRI, false);
             }
         };
@@ -78,7 +78,7 @@ impl CacheOption {
     }
 }
 
-pub enum CachePriority {
+pub(crate) enum CachePriority {
     High,
     Low,
     Bottom,

--- a/photondb/src/tree/mod.rs
+++ b/photondb/src/tree/mod.rs
@@ -685,7 +685,7 @@ impl<'a, E: Env> TreeTxn<'a, E> {
                             return true;
                         }
                         if let Some(ctoken) = ctoken {
-                            ctoken.return_cache_as_cold();
+                            ctoken.return_cache_as_old();
                         }
                         builder.add(SortedPageIter::from(page));
                         page_size += page.size();

--- a/photondb/src/tree/mod.rs
+++ b/photondb/src/tree/mod.rs
@@ -667,6 +667,7 @@ impl<'a, E: Env> TreeTxn<'a, E> {
         let mut last_page = view.page.clone();
         let mut page_addrs = Vec::with_capacity(chain_len);
         let mut range_limit = None;
+        let opt = CacheOption::default().set_refill_cold_when_not_full(true);
         self.walk_page(
             view.addr,
             |addr, page, ctoken| {
@@ -700,7 +701,7 @@ impl<'a, E: Env> TreeTxn<'a, E> {
                 page_addrs.push(addr);
                 false
             },
-            CacheOption::REFILL_COLD_WHEN_NOT_FULL,
+            opt,
         )
         .await?;
         let iter = MergingPageIter::new(builder.build(), range_limit);


### PR DESCRIPTION
Port RocksDB's cache priority to lru implement and let the inner page be inserted as High Priority.

run readrandom (page_size=16k, cache_size=512Mib, reserve 50% for high priority)

before

```
readrandom   :        17.8 micros/op 56026 ops/sec, 713.9 seconds, 40000000 operations; 22.9 MB/s  (reads:40000000 founds:40000000)
Percentiles_Read : P50: 17 ms, P75: 19 ms, P99: 25 ms, P99.9: 29 ms, P99.99: 33 ms, Min: 2 ms, Max: 26623 ms, AVG: 17.825 ms
TreeStats_success: read: 40000000, write: 0, split_page: 0, reconcile_page: 0, consolidate_page: 0, read_bytes: 17120000000, write_bytes: 0
TreeStats_conflict: read: 0, write: 0, split_page: 0, reconcile_page: 0, consolidate_page: 0
WritebufStats: read_in_buf: 0, read_in_files: 319116755, read_file_bytes: 1008701466235, read_hit_rate: 0.00%, miss_inner: 24859976
PageCacheStats: lookup_hit: 215261729, lookup_miss: 103855026, hit_rate: 67.46%, insert: 103855026, active_evict: 0, passive_evict: 103793463, recommendation: []
FileReaderCacheStats: lookup_hit: 103854140, lookup_miss: 886, hit_rate: 99.99914688770093%, insert: 886, active_evict: 0, passive_evict: 0, recommendation: []
BufferSet: stall_writes: 0 stall_intervals_ms: 0
JobStats: flush_write_bytes: 0, flush_discard_bytes: 0, compact_input_bytes: 0, compact_write_bytes: 0, read_file_bytes: 0, write_amp: 0.00
TableStats: user_write_bytes: 0, background_write_bytes: 0, write_amp: NaN, user_read_bytes: 17120000000, front_read_bytes: 1008701466235, background_read_bytes: 0, read_amp: 57.92
```

after 

```
readrandom   :        16.6 micros/op 60124 ops/sec, 665.3 seconds, 40000000 operations; 24.5 MB/s  (reads:40000000 founds:40000000)
Percentiles_Read : P50: 16 ms, P75: 17 ms, P99: 22 ms, P99.9: 26 ms, P99.99: 31 ms, Min: 3 ms, Max: 25951 ms, AVG: 16.625 ms
TreeStats_success: read: 40000000, write: 0, split_page: 0, reconcile_page: 0, consolidate_page: 0, read_bytes: 17120000000, write_bytes: 0
TreeStats_conflict: read: 0, write: 0, split_page: 0, reconcile_page: 0, consolidate_page: 0
WritebufStats: read_in_buf: 0, read_in_files: 319115155, read_file_bytes: 906995516372, read_hit_rate: 0.00%, miss_inner: 33440
PageCacheStats: lookup_hit: 239991504, lookup_miss: 79123651, hit_rate: 75.21%, insert: 79123651, active_evict: 0, passive_evict: 79055485, recommendation: []
FileReaderCacheStats: lookup_hit: 79122765, lookup_miss: 886, hit_rate: 99.99888023367375%, insert: 886, active_evict: 0, passive_evict: 0, recommendation: []
BufferSet: stall_writes: 0 stall_intervals_ms: 0
JobStats: flush_write_bytes: 0, flush_discard_bytes: 0, compact_input_bytes: 0, compact_write_bytes: 0, read_file_bytes: 0, write_amp: 0.00
TableStats: user_write_bytes: 0, background_write_bytes: 0, write_amp: NaN, user_read_bytes: 17120000000, front_read_bytes: 906995516372, background_read_bytes: 0, read_amp: 51.98
```

The inner_page_cache_miss reduce from 7% to 0.01%

